### PR TITLE
Add support for custom OAuth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ To start a flow call:
 // If configured globally, the redirect URL is optional. If provided however, it will be used
 // instead of any global configuration.
 // Redirect the user to the returned URL to start the OAuth redirect chain
-val authURL = Descope.oauth.start(OAuthProvider.Github, redirectURL = "exampleauthschema://my-app.com/handle-oauth")
+val authURL = Descope.oauth.start(OAuthProvider.Github, redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
 ```
 
 Take the generated URL and authenticate the user using `Chrome Custom Tabs`
@@ -385,7 +385,7 @@ To start a flow call:
 // If configured globally, the return URL is optional. If provided however, it will be used
 // instead of any global configuration.
 // Redirect the user to the returned URL to start the SSO/SAML redirect chain
-val authURL = Descope.sso.start(emailOrTenantId = "my-tenant-ID", redirectURL = "exampleauthschema://my-app.com/handle-saml")
+val authURL = Descope.sso.start(emailOrTenantId = "my-tenant-ID", redirectUrl = "exampleauthschema://my-app.com/handle-saml")
 ```
 
 Take the generated URL and authenticate the user using `Chrome Custom Tabs`

--- a/descopesdk/src/main/java/com/descope/Descope.kt
+++ b/descopesdk/src/main/java/com/descope/Descope.kt
@@ -32,11 +32,10 @@ object Descope {
      *
      * - **Note:** This is a shortcut for setting the [Descope.config] property.
      */
-    var projectId: String = ""
+    var projectId: String
         get() = config.projectId
         set(value) {
             config = DescopeConfig(projectId = value)
-            field = value
         }
 
     /**
@@ -133,4 +132,4 @@ val Descope.name: String
 
 /** The Descope SDK version */
 val Descope.version: String
-    get() = "0.9.2"
+    get() = "0.9.3"

--- a/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -1,9 +1,11 @@
 package com.descope.internal.http
 
+import com.descope.Descope
 import com.descope.sdk.DescopeConfig
 import com.descope.types.DeliveryMethod
 import com.descope.types.OAuthProvider
 import com.descope.types.SignUpDetails
+import com.descope.version
 
 internal class DescopeClient(private val config: DescopeConfig) : HttpClient(config.baseUrl) {
 
@@ -332,7 +334,7 @@ internal class DescopeClient(private val config: DescopeConfig) : HttpClient(con
     override val defaultHeaders: Map<String, String> = mapOf(
         "Authorization" to "Bearer ${config.projectId}",
         "x-descope-sdk-name" to "android",
-        "x-descope-sdk-version" to "0.1.0",
+        "x-descope-sdk-version" to Descope.version,
     )
 
     // Internal

--- a/descopesdk/src/main/java/com/descope/sdk/Routes.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Routes.kt
@@ -499,6 +499,12 @@ interface DescopeOAuth {
      * This function returns a URL to redirect to in order to
      * authenticate the user against the chosen [provider].
      *
+     *     // use one of the built in constants for the OAuth provider
+     *     val authUrl = Descope.oauth.start(OAuthProvider.Github, redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+     *
+     *     // or pass a string with the name of a custom provider
+     *     val authUrl = Descope.oauth.start(OAuthProvider("myprovider"), redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+     *
      * - **Important:** Make sure a default OAuth redirect URL is configured
      * in the Descope console, or provided by this call via [redirectUrl]. It should
      * redirect back to this app using a deep link. See examples for more information.

--- a/descopesdk/src/main/java/com/descope/types/Others.kt
+++ b/descopesdk/src/main/java/com/descope/types/Others.kt
@@ -10,13 +10,17 @@ enum class DeliveryMethod {
 }
 
 /** The provider to use in an OAuth flow. */
-enum class OAuthProvider {
-    Facebook,
-    Github,
-    Google,
-    Microsoft,
-    Gitlab,
-    Apple,
+data class OAuthProvider(val name: String) {
+    companion object {
+        val Facebook = OAuthProvider("facebook")
+        val Github = OAuthProvider("github")
+        val Google = OAuthProvider("google")
+        val Microsoft = OAuthProvider("microsoft")
+        val Gitlab = OAuthProvider("gitlab")
+        val Apple = OAuthProvider("apple")
+        val Slack = OAuthProvider("slack")
+        val Discord = OAuthProvider("discord")
+    }
 }
 
 // Classes


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/4097

## Description
- Adds backwards compatible way to specify custom `OAuthProvider` values

## Must
- [X] Tests
- [X] Documentation (if applicable)
