### PR TITLE
Protect against encrypted storage initialization error while developing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ written for Android. You can read more on the [Descope Website](https://descope.
 Add the following to your `build.gradle` dependencies:
 
 ```groovy
-implementation 'com.descope:descope-kotlin:0.9.4'
+implementation 'com.descope:descope-kotlin:0.9.5'
 ```
 
 ## Quickstart

--- a/descopesdk/build.gradle
+++ b/descopesdk/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         minSdk 24
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
@@ -54,7 +54,7 @@ class DescopeSdk(val config: DescopeConfig) {
     private var manager: DescopeSessionManager? = null
 
     private fun initDefaultManager(): DescopeSessionManager {
-        val storage = SessionStorage(config.projectId)
+        val storage = SessionStorage(config.projectId, config.logger)
         val lifecycle = SessionLifecycle(auth)
         val manager = DescopeSessionManager(storage, lifecycle)
         this.manager = manager
@@ -68,6 +68,6 @@ class DescopeSdk(val config: DescopeConfig) {
         const val name = "DescopeAndroid"
 
         /** The Descope SDK version */
-        const val version = "0.9.4"
+        const val version = "0.9.5"
     }
 }


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/4937

## Description

In some cases during development, the encryption key might change. 
The default encrypted storage is now takes it into account.
 
## Must

-   [x] Tests
-   [x] Documentation (if applicable)
