### PR TITLE
Replace config and projectId setters with setup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,20 @@ the Descope Console.
 
 ```kotlin
 import com.descope.Descope
-import com.descope.sdk.DescopeConfig
 
 // Application on create
 override fun onCreate() {
-    Descope.projectId = "<Your-Project-Id>"
+    Descope.setup(this, projectId = "<Your-Project-Id>")
+
+    // Optionally, you can configure your SDK to your needs
+    Descope.setup(this, projectId = "<Your-Project-Id>") {
+        // set a custom base URL (needs to be set up in the Descope console)
+        baseUrl = "https://my.app.com"
+        // enable the logger
+        if (BuildConfig.DEBUG) {
+            logger = DescopeLogger()
+        }
+    }
 }
 ```
 
@@ -130,7 +139,7 @@ an authenticated user.
 // Application class onCreate
 override fun onCreate() {
     super.onCreate()
-    Descope.projectId = "..."
+    Descope.setup(this, projectId = "<Your-Project-Id>")
     Descope.sessionManager.session?.run {
         print("User is logged in: $this")
     }

--- a/descopesdk/src/main/java/com/descope/sdk/Config.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Config.kt
@@ -1,33 +1,31 @@
 package com.descope.sdk
 
+import com.descope.session.DescopeSessionManager
 import java.net.URL
 
 /**
  * The configuration of the Descope SDK.
  *
  * @property projectId The ID of the Descope project.
- * @property baseUrl An optional override for the base URL of the Descope server.
- * @property logger An optional logger to use for logging messages in the Descope SDK.
- * - _**IMPORTANT**: Logging is intended for `DEBUG` only. Do not enable logs when building
- * the `RELEASE` versions of your application._
- * @property networkClient An optional object to override how HTTP requests are performed.
- *  - The default value of this property is always `null`, and the SDK uses its own
- *  internal network client to perform HTTP requests.
- *  - This property can be useful to test code that uses the Descope SDK without any
- *  network requests actually taking place. In most other cases there shouldn't be
- *  any need to use it.
  */
-data class DescopeConfig(
-    val projectId: String,
-    val baseUrl: String? = null,
-    val logger: DescopeLogger? = null,
-    val networkClient: DescopeNetworkClient? = null,
-) {
-
-    companion object {
-        val initial = DescopeConfig("")
-    }
-
+class DescopeConfig(val projectId: String) {
+    /** An optional override for the base URL of the Descope server. */
+    var baseUrl: String? = null
+    /**
+     * An optional logger to use for logging messages in the Descope SDK.
+     * - _**IMPORTANT**: Logging is intended for `DEBUG` only. Do not enable logs when building
+     * the `RELEASE` versions of your application._
+     */
+    var logger: DescopeLogger? = null
+    /**
+     * An optional object to override how HTTP requests are performed.
+     *  - The default value of this property is always `null`, and the SDK uses its own
+     *  internal network client to perform HTTP requests.
+     *  - This property can be useful to test code that uses the Descope SDK without any
+     *  network requests actually taking place. In most other cases there shouldn't be
+     *  any need to use it.
+     */
+    var networkClient: DescopeNetworkClient? = null
 }
 
 /** 

--- a/descopesdk/src/main/java/com/descope/session/Manager.kt
+++ b/descopesdk/src/main/java/com/descope/session/Manager.kt
@@ -46,7 +46,7 @@ import java.net.URLConnection
  *
  *     // Application class onCreate
  *     override fun onCreate() {
- *       super.onCreate()
+ *         super.onCreate()
  *         Descope.setup(this, projectId = "<Your-Project-Id>")
  *         Descope.sessionManager.session?.run {
  *             print("User is logged in: $this")
@@ -57,8 +57,8 @@ import java.net.URLConnection
  * session and clear it from the session manager:
  *
  *     Descope.sessionManager.session?.refreshJwt?.run {
- *       Descope.auth.logout(this)
- *       Descope.sessionManager.clearSession()
+ *         Descope.auth.logout(this)
+ *         Descope.sessionManager.clearSession()
  *     }
  *
  * You can customize how the `DescopeSessionManager` behaves by using your own

--- a/descopesdk/src/main/java/com/descope/session/Manager.kt
+++ b/descopesdk/src/main/java/com/descope/session/Manager.kt
@@ -47,7 +47,7 @@ import java.net.URLConnection
  *     // Application class onCreate
  *     override fun onCreate() {
  *       super.onCreate()
- *         Descope.projectId = "..."
+ *         Descope.setup(this, projectId = "<Your-Project-Id>")
  *         Descope.sessionManager.session?.run {
  *             print("User is logged in: $this")
  *         }

--- a/descopesdk/src/main/java/com/descope/session/Storage.kt
+++ b/descopesdk/src/main/java/com/descope/session/Storage.kt
@@ -65,22 +65,18 @@ interface DescopeSessionStorage {
  * instance of that class to the constructor to create a [SessionStorage] object
  * that uses a different backing store.
  *
+ * @param context the application context
  * @property projectId the Descope projectId
  * @param logger an optional [DescopeLogger] for logging during development
  * @param store an optional implementation of [SessionStorage.Store]
  */
-class SessionStorage(private val projectId: String, logger: DescopeLogger? = null, store: Store? = null) : DescopeSessionStorage {
+class SessionStorage(context: Context, private val projectId: String, logger: DescopeLogger? = null, store: Store? = null) : DescopeSessionStorage {
 
     private val store: Store
     private var lastValue: Value? = null
 
     init {
-        val context = Descope.provideApplicationContext?.invoke()
-        this.store = when {
-            store != null -> store
-            context != null -> createEncryptedStore(context, projectId, logger)
-            else -> Store.none
-        }
+        this.store = store ?: createEncryptedStore(context, projectId, logger)
     }
 
     override fun saveSession(session: DescopeSession) {


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/5672

## Description

**BREAKING CHANGE**
Replace initialization by way of setters and lazy loading to an explicit `Descope.setup()` function, and  a corresponding `DescopeSdk` constructor.

## Must

- [X] Tests
- [X] Documentation (if applicable)
