### PR TITLE
Support sign up in or both for oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ To start a flow call:
 // If configured globally, the redirect URL is optional. If provided however, it will be used
 // instead of any global configuration.
 // Redirect the user to the returned URL to start the OAuth redirect chain
-val authURL = Descope.oauth.start(OAuthProvider.Github, redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+val authURL = Descope.oauth.signUpOrIn(OAuthProvider.Github, redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
 ```
 
 Take the generated URL and authenticate the user using `Chrome Custom Tabs`

--- a/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -357,8 +357,8 @@ internal class DescopeClient(internal val config: DescopeConfig) : HttpClient(co
 
     // OAuth
 
-    suspend fun oauthWebStart(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?): OAuthServerResponse = post(
-        route = "auth/oauth/authorize",
+    suspend fun oauthWebStart(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?, oAuthMethod: OAuthMethod): OAuthServerResponse = post(
+        route = "auth/oauth/authorize${oAuthMethod.routeSuffix}",
         decoder = OAuthServerResponse::fromJson,
         headers = authorization(options?.refreshJwt),
         params = mapOf(
@@ -484,6 +484,14 @@ internal fun baseUrlForProjectId(projectId: String): String {
         val region = projectId.substring(1..4)
         "$prefix.$region.$suffix"
     } else "$prefix.$suffix" 
+}
+
+// Internal Classes
+
+enum class OAuthMethod(val routeSuffix: String) {
+    SignUp("/signup"),
+    SignIn("/signin"),
+    SignUpOrIn("")
 }
 
 // Extensions

--- a/descopesdk/src/main/java/com/descope/internal/routes/OAuth.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/OAuth.kt
@@ -9,6 +9,7 @@ import androidx.credentials.GetCredentialResponse
 import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialException
 import com.descope.internal.http.DescopeClient
+import com.descope.internal.http.OAuthMethod
 import com.descope.internal.others.with
 import com.descope.sdk.DescopeOAuth
 import com.descope.types.AuthenticationResponse
@@ -22,13 +23,27 @@ import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingExcept
 
 internal class OAuth(override val client: DescopeClient):  Route, DescopeOAuth {
 
-    override suspend fun start(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?): String =
-        client.oauthWebStart(provider, redirectUrl, options).url
+    override suspend fun signUp(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?): String =
+        client.oauthWebStart(provider, redirectUrl, options, OAuthMethod.SignUp).url
 
-    override fun start(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?, callback: (Result<String>) -> Unit) = wrapCoroutine(callback) {
-        start(provider, redirectUrl, options)
+    override fun signUp(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?, callback: (Result<String>) -> Unit) = wrapCoroutine(callback) {
+        signUp(provider, redirectUrl, options)
+    }
+    
+    override suspend fun signIn(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?): String =
+        client.oauthWebStart(provider, redirectUrl, options, OAuthMethod.SignIn).url
+
+    override fun signIn(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?, callback: (Result<String>) -> Unit) = wrapCoroutine(callback) {
+        signIn(provider, redirectUrl, options)
     }
 
+    override suspend fun signUpOrIn(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?): String =
+        client.oauthWebStart(provider, redirectUrl, options, OAuthMethod.SignUpOrIn).url
+
+    override fun signUpOrIn(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?, callback: (Result<String>) -> Unit) = wrapCoroutine(callback) {
+        signUpOrIn(provider, redirectUrl, options)
+    }
+    
     override suspend fun exchange(code: String): AuthenticationResponse =
         client.oauthWebExchange(code).convert()
 
@@ -91,4 +106,14 @@ internal class OAuth(override val client: DescopeClient):  Route, DescopeOAuth {
 
         return result.idToken
     }
+    
+    // Deprecated
+
+    @Deprecated(message = "Use signUpOrIn instead", replaceWith = ReplaceWith("signUpOrIn(provider, redirectUrl, options)"))
+    override suspend fun start(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?): String =
+        signUpOrIn(provider, redirectUrl, options)
+
+    @Deprecated(message = "Use signUpOrIn instead", replaceWith = ReplaceWith("signUpOrIn(provider, redirectUrl, options, callback)"))
+    override fun start(provider: OAuthProvider, redirectUrl: String?, options: List<SignInOptions>?, callback: (Result<String>) -> Unit) = 
+        signUpOrIn(provider, redirectUrl, options, callback)
 }

--- a/descopesdk/src/main/java/com/descope/sdk/Routes.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Routes.kt
@@ -519,6 +519,85 @@ interface DescopeEnchantedLink {
 interface DescopeOAuth {
 
     /**
+     * Authenticates a new user using an OAuth redirect chain.
+     *
+     * This function returns a URL to redirect to in order to
+     * authenticate the user against the chosen [provider].
+     *
+     *     // use one of the built in constants for the OAuth provider
+     *     val authUrl = Descope.oauth.signUp(OAuthProvider.Github, redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+     *
+     *     // or pass a string with the name of a custom provider
+     *     val authUrl = Descope.oauth.signUp(OAuthProvider("myprovider"), redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+     *
+     * - **Important:** Make sure a default OAuth redirect URL is configured
+     * in the Descope console, or provided by this call via [redirectUrl]. It should
+     * redirect back to this app using a deep link. See examples for more information.
+     *
+     * @param provider which provider to authenticate against
+     * @param redirectUrl optional redirect URL. If null, the default redirect URL in Descope console will be used.
+     * @param options additional behaviors to perform during authentication.
+     * @return a URL that starts the OAuth redirect chain
+     */
+    suspend fun signUp(provider: OAuthProvider, redirectUrl: String? = null, options: List<SignInOptions>? = null): String
+
+    /** @see signUp */
+    fun signUp(provider: OAuthProvider, redirectUrl: String? = null, options: List<SignInOptions>? = null, callback: (Result<String>) -> Unit)
+
+    /**
+     * Authenticates an existing user using an OAuth redirect chain.
+     *
+     * This function returns a URL to redirect to in order to
+     * authenticate the user against the chosen [provider].
+     *
+     *     // use one of the built in constants for the OAuth provider
+     *     val authUrl = Descope.oauth.signIn(OAuthProvider.Github, redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+     *
+     *     // or pass a string with the name of a custom provider
+     *     val authUrl = Descope.oauth.signIn(OAuthProvider("myprovider"), redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+     *
+     * - **Important:** Make sure a default OAuth redirect URL is configured
+     * in the Descope console, or provided by this call via [redirectUrl]. It should
+     * redirect back to this app using a deep link. See examples for more information.
+     *
+     * @param provider which provider to authenticate against
+     * @param redirectUrl optional redirect URL. If null, the default redirect URL in Descope console will be used.
+     * @param options additional behaviors to perform during authentication.
+     * @return a URL that starts the OAuth redirect chain
+     */
+    suspend fun signIn(provider: OAuthProvider, redirectUrl: String? = null, options: List<SignInOptions>? = null): String
+
+    /** @see signIn */
+    fun signIn(provider: OAuthProvider, redirectUrl: String? = null, options: List<SignInOptions>? = null, callback: (Result<String>) -> Unit)
+
+    /**
+     * Authenticates an existing user if one exists, or create a new user using an
+     * OAuth redirect chain.
+     *
+     * This function returns a URL to redirect to in order to
+     * authenticate the user against the chosen [provider].
+     *
+     *     // use one of the built in constants for the OAuth provider
+     *     val authUrl = Descope.oauth.signUpOrIn(OAuthProvider.Github, redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+     *
+     *     // or pass a string with the name of a custom provider
+     *     val authUrl = Descope.oauth.signUpOrIn(OAuthProvider("myprovider"), redirectUrl = "exampleauthschema://my-app.com/handle-oauth")
+     *
+     * - **Important:** Make sure a default OAuth redirect URL is configured
+     * in the Descope console, or provided by this call via [redirectUrl]. It should
+     * redirect back to this app using a deep link. See examples for more information.
+     *
+     * @param provider which provider to authenticate against
+     * @param redirectUrl optional redirect URL. If null, the default redirect URL in Descope console will be used.
+     * @param options additional behaviors to perform during authentication.
+     * @return a URL that starts the OAuth redirect chain
+     */
+    suspend fun signUpOrIn(provider: OAuthProvider, redirectUrl: String? = null, options: List<SignInOptions>? = null): String
+
+    /** @see signUpOrIn */
+    fun signUpOrIn(provider: OAuthProvider, redirectUrl: String? = null, options: List<SignInOptions>? = null, callback: (Result<String>) -> Unit)
+    
+    /**
      * Starts an OAuth redirect chain to authenticate a user.
      *
      * This function returns a URL to redirect to in order to
@@ -539,9 +618,11 @@ interface DescopeOAuth {
      * @param options additional behaviors to perform during authentication.
      * @return a URL that starts the OAuth redirect chain
      */
+    @Deprecated(message = "Use signUpOrIn instead", replaceWith = ReplaceWith("signUpOrIn(provider, redirectUrl, options)"))
     suspend fun start(provider: OAuthProvider, redirectUrl: String? = null, options: List<SignInOptions>? = null): String
 
     /** @see start */
+    @Deprecated(message = "Use signUpOrIn instead", replaceWith = ReplaceWith("signUpOrIn(provider, redirectUrl, options, callback)"))
     fun start(provider: OAuthProvider, redirectUrl: String? = null, options: List<SignInOptions>? = null, callback: (Result<String>) -> Unit)
 
     /**
@@ -550,6 +631,11 @@ interface DescopeOAuth {
      * This function exchanges the [code] received in the `code` URL
      * parameter for an [AuthenticationResponse].
      *
+     * - **Important:** The redirect URL might not contain a code URL parameter
+     *   but can contain an `err` URL parameter instead. This can occur when attempting to
+     *   [signUp] with an existing user or trying to [signIn] with a non-existing
+     *   user.
+     * 
      * @param code received in the final redirect as a url parameter named `code`
      * @return an [AuthenticationResponse] upon successful verification.
      */


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/5696

## Description

- Deprecate OAuth `start` in favor of `signUpOrIn`
- Add `signUp` and `signIn` to OAuth

## Must

-   [x] Tests
-   [x] Documentation (if applicable)
