### PR TITLE
Token and session updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ as ensuring that it's refreshed when needed. For the default instances of
 the `DescopeSessionManager` class this means using the `EncryptedSharedPreferences`
 for secure storage of the session and refreshing it a short while before it expires.
 
-**Important**: If you're planning on using the default session storage, make sure to provide
-the application context when initializing `Descope` with a project ID / config:
+Make sure you initialize Descope with your application context so that the
+session manager implementation can access Android storage and load any
+existing session and user data:
 
 ```kotlin
-Descope.config = DescopeConfig(projectId = "<PROJECT-ID>")
-Descope.provideApplicationContext = { applicationContext }
+Descope.setup(applicationContext, projectId = "<PROJECT-ID>")
 ```
 
 Once the user completes a sign in flow successfully you should set the

--- a/descopesdk/src/main/java/com/descope/session/Lifecycle.kt
+++ b/descopesdk/src/main/java/com/descope/session/Lifecycle.kt
@@ -77,8 +77,9 @@ class SessionLifecycle(private val auth: DescopeAuth) : DescopeSessionLifecycle 
 
     // Internal
 
-    private fun shouldRefresh(session: DescopeSession): Boolean =
-        session.sessionToken.expiresAt?.run { this - System.currentTimeMillis() <= stalenessAllowedInterval } ?: false
+    private fun shouldRefresh(session: DescopeSession): Boolean {
+        return session.sessionToken.expiresAt - System.currentTimeMillis() <= stalenessAllowedInterval
+    }
 
     // Timer
 

--- a/descopesdk/src/main/java/com/descope/session/Session.kt
+++ b/descopesdk/src/main/java/com/descope/session/Session.kt
@@ -4,6 +4,7 @@ import android.text.format.DateFormat
 import com.descope.types.AuthenticationResponse
 import com.descope.types.DescopeUser
 import com.descope.types.RefreshResponse
+import java.util.Objects
 
 /**
  * The `DescopeSession` class represents a successful sign in operation.
@@ -38,7 +39,6 @@ import com.descope.types.RefreshResponse
  * @param refreshToken the long lived refresh token received inside an [AuthenticationResponse].
  * @param user the authenticated user received from an [AuthenticationResponse] or a `me` request.
  */
-@Suppress("EqualsOrHashCode")
 class DescopeSession(sessionToken: DescopeToken, refreshToken: DescopeToken, user: DescopeUser) {
     /**
      * The wrapper for the short lived JWT that can be sent with every server
@@ -79,95 +79,104 @@ class DescopeSession(sessionToken: DescopeToken, refreshToken: DescopeToken, use
      * the application is relaunched if not using a `DescopeSessionManager` for this.
      */
     constructor(sessionJwt: String, refreshJwt: String, user: DescopeUser) : this(Token(sessionJwt), Token(refreshJwt), user)
+    
+    //
+    // Convenience accessors for getting values from the underlying JWTs.
+    //
 
-    // Enable correct comparison between sessions
+    /** The short lived JWT that is sent with every request that requires authentication. */
+    val sessionJwt: String
+        get() = sessionToken.jwt
+
+    /** The longer lived JWT that is used to create new session JWTs until it expires. */
+    val refreshJwt: String
+        get() = refreshToken.jwt
+
+    /**
+     * A map with all the custom claims in the underlying JWT. It includes
+     * any claims whose values aren't already exposed by other accessors or
+     * authorization functions.
+     */
+    val claims: Map<String, Any>
+        get() = refreshToken.claims
+
+    /**
+     * Returns the list of permissions granted for the user. Leave tenant as `null`
+     * if the user isn't associated with any tenant.
+     *
+     * @param tenant optional tenant ID to get tenant permissions, if the user belongs to that tenant.
+     * @return a list of permissions for the user.
+     */
+    fun permissions(tenant: String? = null): List<String> = refreshToken.permissions(tenant)
+
+    /**
+     * Returns the list of roles for the user. Leave tenant as `null`
+     * if the user isn't associated with any tenant.
+     *
+     * @param tenant optional tenant ID to get tenant roles, if the user belongs to that tenant.
+     * @return a list of roles for the user.
+     */
+    fun roles(tenant: String? = null): List<String> = refreshToken.roles(tenant)
+
+    //
+    // Updating the session manually when not using a `DescopeSessionManager`.
+    //
+
+    /**
+     * Updates the underlying JWTs with those from a `RefreshResponse`.
+     *
+     *     if (session.sessionToken.isExpired) {
+     *         val refreshResponse = Descope.auth.refreshSession(session.refreshJwt)
+     *         session.updateTokens(refreshResponse)
+     *     }
+     *
+     * Important: It's recommended to use a `DescopeSessionManager` to manage sessions,
+     * in which case you should call `updateTokens` on the manager itself, or
+     * just call `refreshSessionIfNeeded` to do everything for you.
+     *
+     * @param refreshResponse the response to manually update from.
+     */
+    fun updateTokens(refreshResponse: RefreshResponse) {
+        sessionToken = refreshResponse.sessionToken
+        refreshToken = refreshResponse.refreshToken ?: refreshToken
+    }
+
+    /**
+     * Updates the session user's details with those from another `DescopeUser` value.
+     *
+     *     val userResponse = Descope.auth.me(session.refreshJwt)
+     *     session.updateUser(userResponse)
+     *
+     * Important: It's recommended to use a `DescopeSessionManager` to manage sessions,
+     * in which case you should call `updateUser` on the manager itself instead
+     * to ensure that the updated user details are saved.
+     *
+     * @param descopeUser the user to manually update from.
+     */
+    fun updateUser(descopeUser: DescopeUser) {
+        user = descopeUser
+    }
+    
+    // Utilities
+    
     override fun equals(other: Any?): Boolean {
         val session = other as? DescopeSession ?: return false
         return sessionJwt == session.sessionJwt &&
-                refreshJwt == session.refreshJwt &&
-                user == session.user
+            refreshJwt == session.refreshJwt &&
+            user == session.user
     }
 
+    override fun hashCode(): Int {
+        return Objects.hash(sessionJwt, refreshJwt, user)
+    }
+    
+    /**
+     * Returns a safe string representation of the session with the `userId`
+     * and refresh token expiry time (i.e., no private or secret data).
+     */
     override fun toString(): String {
-        var expires = "expires=Never"
-        refreshToken.expiresAt?.let {
-            val label = if (refreshToken.isExpired) "expired" else "expires"
-            val date = DateFormat.format("yyyy-MM-dd HH:mm:ss", it)
-            expires = "$label=$date"
-        }
-        return "DescopeSession(userId=${user.userId}, $expires)"
+        val expires = if (refreshToken.isExpired) "expired" else "expires"
+        val date = DateFormat.format("yyyy-MM-dd HH:mm:ss", refreshToken.expiresAt)
+        return "DescopeSession(userId=${user.userId}, $expires=$date)"
     }
-}
-
-// Convenience accessors for getting values from the underlying JWTs.
-
-/** The short lived JWT that is sent with every request that requires authentication. */
-val DescopeSession.sessionJwt: String
-    get() = sessionToken.jwt
-
-/** The longer lived JWT that is used to create new session JWTs until it expires. */
-val DescopeSession.refreshJwt: String
-    get() = refreshToken.jwt
-
-/**
- * A map with all the custom claims in the underlying JWT. It includes
- * any claims whose values aren't already exposed by other accessors or
- * authorization functions.
- */
-val DescopeSession.claims: Map<String, Any>
-    get() = refreshToken.claims
-
-/**
- * Returns the list of permissions granted for the user. Leave tenant as `null`
- * if the user isn't associated with any tenant.
- *
- * @param tenant optional tenant ID to get tenant permissions, if the user belongs to that tenant.
- * @return a list of permissions for the user.
- */
-fun DescopeSession.permissions(tenant: String? = null): List<String> = refreshToken.permissions(tenant)
-
-/**
- * Returns the list of roles for the user. Leave tenant as `null`
- * if the user isn't associated with any tenant.
- *
- * @param tenant optional tenant ID to get tenant roles, if the user belongs to that tenant.
- * @return a list of roles for the user.
- */
-fun DescopeSession.roles(tenant: String? = null): List<String> = refreshToken.roles(tenant)
-
-// Updating the session manually when not using a `DescopeSessionManager`.
-
-/**
- * Updates the underlying JWTs with those from a `RefreshResponse`.
- *
- *     if (session.sessionToken.isExpired) {
- *         val refreshResponse = Descope.auth.refreshSession(session.refreshJwt)
- *         session.updateTokens(refreshResponse)
- *     }
- *
- * Important: It's recommended to use a `DescopeSessionManager` to manage sessions,
- * in which case you should call `updateTokens` on the manager itself, or
- * just call `refreshSessionIfNeeded` to do everything for you.
- *
- * @param refreshResponse the response to manually update from.
- */
-fun DescopeSession.updateTokens(refreshResponse: RefreshResponse) {
-    sessionToken = refreshResponse.sessionToken
-    refreshToken = refreshResponse.refreshToken ?: refreshToken
-}
-
-/**
- * Updates the session user's details with those from another `DescopeUser` value.
- *
- *     val userResponse = Descope.auth.me(session.refreshJwt)
- *     session.updateUser(userResponse)
- *
- * Important: It's recommended to use a `DescopeSessionManager` to manage sessions,
- * in which case you should call `updateUser` on the manager itself instead
- * to ensure that the updated user details are saved.
- *
- * @param descopeUser the user to manually update from.
- */
-fun DescopeSession.updateUser(descopeUser: DescopeUser) {
-    user = descopeUser
 }

--- a/descopesdk/src/main/java/com/descope/session/Storage.kt
+++ b/descopesdk/src/main/java/com/descope/session/Storage.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
-import com.descope.Descope
 import com.descope.internal.others.optionalMap
 import com.descope.internal.others.stringOrEmptyAsNull
 import com.descope.internal.others.toJsonArray
@@ -49,15 +48,14 @@ interface DescopeSessionStorage {
  * The default implementation of the [DescopeSessionStorage] interface.
  *
  * By default, the `SessionStorage` persists the [DescopeSession] securely using
- * [EncryptedSharedPreferences]. This another layer of precaution over the fact
- * that applications are sandboxed.
+ * [EncryptedSharedPreferences]. This provides another layer of safety over
+ * the fact that Android applications and all their data are sandboxed.
  *
  * - **NOTE:** In order to take advantage of the [EncryptedSharedPreferences] based
- * storage, you must make sure [Descope.provideApplicationContext] provides the application
- * context and is not `null`:
+ * storage, the Descope SDK initializers require a [Context] argument, and you should
+ * always make sure to pass the `applicationContext` there:
  *
- *
- *     Descope.provideApplicationContext = { applicationContext }
+ *     Descope.setup(applicationContext, projectId = "DESCOPE_PROJECT_ID")
  *
  * For your convenience, you can implement the [SessionStorage.Store] class and
  * override the [SessionStorage.Store.loadItem], [SessionStorage.Store.saveItem]

--- a/descopesdk/src/test/java/com/descope/session/TokenTest.kt
+++ b/descopesdk/src/test/java/com/descope/session/TokenTest.kt
@@ -5,13 +5,30 @@ import org.junit.Test
 
 class TokenTest {
 
-    private val encoded = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.4Adcj3UFYzPUVaVF43FmMab6RlaQD8A9V8wFzzht-KQ"
+    private val encoded = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJodHRwczovL2Rlc2NvcGUuY29tL2JsYS9QMTIzIiwiZXhwIjoxNjAzMTc2NjE0LCJwZXJtaXNzaW9ucyI6WyJkIiwiZSJdLCJyb2xlcyI6WyJ1c2VyIl0sInRlbmFudHMiOnsidGVuYW50Ijp7InBlcm1pc3Npb25zIjpbImEiLCJiIiwiYyJdLCJyb2xlcyI6WyJhZG1pbiJdfX19.MCSE6ZTlD0oVS0FhXe5LwBpbUVG8H5RmwU7sk_L7Bbo"
 
     @Test
     fun jwt_decode() {
-        val decoded = decodeJwt(encoded)
-        assertEquals("1234567890", decoded["sub"])
-        assertEquals("John Doe", decoded["name"])
-        assertEquals(1516239022, decoded["exp"])
+        val token = Token(encoded)
+
+        assertEquals(encoded, token.jwt)
+        
+        // Basic Fields
+        assertEquals("1234567890", token.entityId)
+        assertEquals("P123", token.projectId)
+        assertEquals(1603176614000, token.expiresAt)
+        
+        // Custom Claims
+        assertEquals("John Doe", token.claims["name"])
+        assertEquals(1, token.claims.size)
+
+        // Authorization
+        assertEquals(listOf("d", "e"), token.permissions(tenant = null))
+        assertEquals(listOf("user"), token.roles(tenant = null))
+
+        // Tenant Authorization
+        assertEquals(listOf("a", "b", "c"), token.permissions(tenant = "tenant"))
+        assertEquals(listOf("admin"), token.roles(tenant = "tenant"))
+        assertEquals(emptyList<String>(), token.permissions(tenant = "no-such-tenant"))
     }
 }


### PR DESCRIPTION
## Description
- Make `expiresAt` field non-optional
- Add `issuedAt` accessor
- Don't filter `aud` claim from `claims` accessor as we don't currently expose it otherwise
- **BREAKING CHANGE**: Change `id` property in `DescopeToken` to `entityId`
- Some docs and tests updates

## Must
- [X] Tests
- [X] Documentation (if applicable)

