### PR TITLE
Throw `DescopeException` when browser fails to launch

### DIFF
--- a/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -399,6 +399,7 @@ internal class DescopeClient(internal val config: DescopeConfig) : HttpClient(co
         body = mapOf(
             "provider" to provider.name,
             "loginOptions" to options?.toMap(),
+            "implicit" to true,
         ),
     )
 

--- a/descopesdk/src/main/java/com/descope/internal/routes/Flow.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/Flow.kt
@@ -108,8 +108,12 @@ internal class Flow(
         }
 
         private fun launchUri(context: Context, uri: Uri) {
-            val customTabsIntent = flowPresentation?.createCustomTabsIntent(context) ?: defaultCustomTabIntent()
-            customTabsIntent.launchUrl(context, uri)
+            try {
+                val customTabsIntent = flowPresentation?.createCustomTabsIntent(context) ?: defaultCustomTabIntent()
+                customTabsIntent.launchUrl(context, uri)
+            } catch (e: Exception) {
+                throw DescopeException.browserError.with(message = e.message)
+            }
         }
 
     }

--- a/descopesdk/src/main/java/com/descope/internal/routes/Flow.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/Flow.kt
@@ -112,7 +112,7 @@ internal class Flow(
                 val customTabsIntent = flowPresentation?.createCustomTabsIntent(context) ?: defaultCustomTabIntent()
                 customTabsIntent.launchUrl(context, uri)
             } catch (e: Exception) {
-                throw DescopeException.browserError.with(message = e.message)
+                throw DescopeException.browserError.with(cause = e)
             }
         }
 

--- a/descopesdk/src/main/java/com/descope/sdk/Routes.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Routes.kt
@@ -656,13 +656,13 @@ interface DescopeOAuth {
      * the user sign in with the Google account they're already using on their device.
      *
      * If you haven't already configured your app to support Sign in with Google you'll
-     * probably need to set up your [Google APIs console project](https://developers.google.com/identity/one-tap/android/get-started#api-console)
+     * probably need to set up your [Google APIs console project](https://developer.android.com/identity/sign-in/credential-manager-siwg#set-google)
      * for this. You should also configure an OAuth provider for Google in the in the [Descope console](https://app.descope.com/settings/authentication/social),
      * with its `Grant Type` set to `Implicit`. Also note that the `Client ID` and
      * `Client Secret` should be set to the values of your `Web application` OAuth client,
      * rather than those from the `Android` OAuth client.
      * 
-     * For more details about configuring your app see the [Credential Manager documentation](https://developer.android.com/training/sign-in/credential-manager).
+     * For more details about configuring your app see the [Credential Manager documentation](https://developer.android.com/identity/sign-in/credential-manager).
      *
      * Note: This is an asynchronous operation that performs network requests before and
      * after displaying the modal authentication view. It is thus recommended to switch the

--- a/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
@@ -69,6 +69,6 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         const val name = "DescopeAndroid"
 
         /** The Descope SDK version */
-        const val version = "0.11.1"
+        const val version = "0.11.2"
     }
 }

--- a/descopesdk/src/main/java/com/descope/types/Error.kt
+++ b/descopesdk/src/main/java/com/descope/types/Error.kt
@@ -92,7 +92,7 @@ class DescopeException(
          * offline or the network request timing out.
          */
         val networkError = DescopeException(code = "K010001", desc = "Network error")
-        val browserError = DescopeException(code = "K100002", desc = "Unable to launch browser")
+        val browserError = DescopeException(code = "K010002", desc = "Unable to launch browser")
 
         val badRequest = DescopeException(code = "E011001", desc = API_DESC)
         val missingArguments = DescopeException(code = "E011002", desc = API_DESC)

--- a/descopesdk/src/main/java/com/descope/types/Error.kt
+++ b/descopesdk/src/main/java/com/descope/types/Error.kt
@@ -92,6 +92,7 @@ class DescopeException(
          * offline or the network request timing out.
          */
         val networkError = DescopeException(code = "K010001", desc = "Network error")
+        val browserError = DescopeException(code = "K100002", desc = "Unable to launch browser")
 
         val badRequest = DescopeException(code = "E011001", desc = API_DESC)
         val missingArguments = DescopeException(code = "E011002", desc = API_DESC)


### PR DESCRIPTION
## Description

- Throw `DescopeException` when browser fails to launch.
- Add passkey implicit flag
- Fix doc links
- Bump patch version
