### PR TITLE
Add option to logout all previous JWTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,16 @@ active session and clear it from the session manager:
 }
 ```
 
+When the user wants revoke previous (other machines)
+active session:
+
+```kotlin
+ Descope.sessionManager.session?.refreshJwt?.run {
+    Descope.auth.logoutPrevious(this)
+    Descope.sessionManager.clearSession()
+}
+```
+
 You can customize how the `DescopeSessionManager` behaves by using
 your own `storage` and `lifecycle` objects. See the documentation
 for more details.

--- a/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -475,6 +475,13 @@ internal open class DescopeClient(internal val config: DescopeConfig) : HttpClie
         headers = authorization(refreshJwt),
     )
 
+    suspend fun logoutPrevious(refreshJwt: String) = post(
+        route = "auth/logoutprevious",
+        decoder = emptyResponse,
+        headers = authorization(refreshJwt),
+    )
+
+
     // Overrides
 
     override val basePath = "/v1/"

--- a/descopesdk/src/main/java/com/descope/internal/routes/Auth.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/Auth.kt
@@ -29,6 +29,9 @@ internal class Auth(private val client: DescopeClient) : DescopeAuth {
         logout(refreshJwt)
     }
 
+    override suspend fun logoutPrevious(refreshJwt: String) =
+        client.logoutPrevious(refreshJwt)
+
     override suspend fun logoutPrevious(refreshJwt: String, callback: (Result<Unit>) -> Unit) = wrapCoroutine(callback) {
         logoutPrevious(refreshJwt)
     }

--- a/descopesdk/src/main/java/com/descope/internal/routes/Auth.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/Auth.kt
@@ -29,4 +29,8 @@ internal class Auth(private val client: DescopeClient) : DescopeAuth {
         logout(refreshJwt)
     }
 
+    override suspend fun logoutPrevious(refreshJwt: String, callback: (Result<Unit>) -> Unit) = wrapCoroutine(callback) {
+        logoutPrevious(refreshJwt)
+    }
+
 }

--- a/descopesdk/src/main/java/com/descope/sdk/Routes.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Routes.kt
@@ -62,6 +62,16 @@ interface DescopeAuth {
 
     /** @see logout */
     suspend fun logout(refreshJwt: String, callback: (Result<Unit>) -> Unit)
+
+    /**
+     * invalidates all sessions that were created prior to this one [DescopeSession].
+     *
+     * @param refreshJwt the refreshJwt from an active [DescopeSession].
+     */
+    suspend fun logoutPrevious(refreshJwt: String)
+
+    /** @see logoutPrevious */
+    suspend fun logoutPrevious(refreshJwt: String, callback: (Result<Unit>) -> Unit)
 }
 
 /**


### PR DESCRIPTION
This new function call, will expire all jwts created prior to the one in the request related to https://github.com/descope/etc/issues/8242
