### PR TITLE
Add default String constructor to DescopeFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ descopeFlowView.listener = object : DescopeFlowView.Listener {
     }
 }
 
-val descopeFlow = DescopeFlow(Uri.parse("<URL_FOR_FLOW_IN_SETUP_#1>"))
+val descopeFlow = DescopeFlow("<URL_FOR_FLOW_IN_SETUP_#1>")
 // set the OAuth provider ID that is configured to "sign in with Google"
 descopeFlow.oauthProvider = OAuthProvider.Google
 // set the oauth redirect URI to use your app's deep link 

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -249,7 +249,7 @@ document.head.appendChild(element)
     internal fun run(flow: DescopeFlow) {
         this.flow = flow
         handleStarted()
-        webView.loadUrl(flow.uri.toString())
+        webView.loadUrl(flow.url)
     }
 
     internal fun resumeFromDeepLink(deepLink: Uri) {

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowView.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowView.kt
@@ -18,11 +18,12 @@ import com.descope.types.OAuthProvider
  * The configuration class required to run a Flow. Provide an instance
  * of this class when calling [DescopeFlowView.run] to run a flow
  * according to the properties provided here.
- *
- * @property uri The URI where the flow is hosted
  */
-data class DescopeFlow(val uri: Uri) {
-
+class DescopeFlow {
+    
+    /** The URL where the flow is hosted. */
+    var url: String
+    
     /** Provide an instance of `DescopeSdk` if a custom instance was initialized. Leave `null` to use [Descope]*/
     var sdk: DescopeSdk? = null
 
@@ -89,6 +90,20 @@ data class DescopeFlow(val uri: Uri) {
      * Customize the [DescopeFlowView] presentation by providing a [Presentation] implementation
      */
     var presentation: Presentation? = null
+
+    /**
+     * Creates a new [DescopeFlow] object.
+     */
+    constructor(url: String) {
+        this.url = url
+    }
+    
+    /**
+     * Creates a new [DescopeFlow] object from a parsed `Uri` instance.
+     * */
+    constructor(uri: Uri) {
+        this.url = uri.toString()
+    }
 
     /**
      * Customize the flow's presentation by implementing the [Presentation] interface.


### PR DESCRIPTION
## Description
Add default `String` constructor to `DescopeFlow` so this:

<kbd><img width="644" alt="Screenshot 2025-02-27 at 16 02 37" src="https://github.com/user-attachments/assets/448151df-f2e0-4703-9e3b-8280a1a196e0" /></kbd>

can now be simply this:

<kbd><img width="513" alt="Screenshot 2025-02-27 at 16 02 48" src="https://github.com/user-attachments/assets/e0f18c04-1b42-41a2-8d89-9025eb0293a8" /></kbd>

## Must
- [X] Tests
- [X] Documentation (if applicable)
