### PR TITLE
Rename `oauthProvider` to `oauthNativeProvider` for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ descopeFlowView.listener = object : DescopeFlowView.Listener {
 
 val descopeFlow = DescopeFlow("<URL_FOR_FLOW_IN_SETUP_#1>")
 // set the OAuth provider ID that is configured to "sign in with Google"
-descopeFlow.oauthProvider = OAuthProvider.Google
+descopeFlow.oauthNativeProvider = OAuthProvider.Google
 // set the oauth redirect URI to use your app's deep link 
 descopeFlow.oauthRedirect = "<URL_FOR_APP_LINK_IN_SETUP_#2>"
 // customize the flow presentation further

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -202,7 +202,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
                     evaluateJavascript(
                         setupScript(
                             origin = origin,
-                            oauthNativeProvider = flow.oauthProvider?.name ?: "",
+                            oauthNativeProvider = flow.oauthNativeProvider?.name ?: "",
                             oauthRedirect = pickRedirectUrl(flow.oauthRedirect, flow.oauthRedirectCustomScheme, useCustomSchemeFallback),
                             ssoRedirect = pickRedirectUrl(flow.ssoRedirect, flow.ssoRedirectCustomScheme, useCustomSchemeFallback),
                             magicLinkRedirect = flow.magicLinkRedirect ?: "",

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowView.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowView.kt
@@ -36,11 +36,11 @@ class DescopeFlow {
     var hooks: List<DescopeFlowHook> = emptyList()
 
     /**
-     * The ID of the oauth provider that is configured to correctly "Sign In with Google".
+     * The ID of the oauth provider that is configured to natively "Sign In with Google".
      * Will likely be "google" if the Descope "Google" provider was customized,
      * or alternatively a custom provider ID.
      */
-    var oauthProvider: OAuthProvider? = null
+    var oauthNativeProvider: OAuthProvider? = null
 
     /**
      * An optional deep link link URL to use when performing OAuth authentication, overriding
@@ -119,6 +119,16 @@ class DescopeFlow {
          */
         fun createCustomTabsIntent(context: Context): CustomTabsIntent?
     }
+
+    /**
+     * Has been renamed and replaced by [oauthNativeProvider]. Use it instead.
+     */
+    @Deprecated(message = "Use oauthNativeProvider instead", replaceWith = ReplaceWith("oauthNativeProvider"))
+    var oauthProvider: OAuthProvider?
+        get() = oauthNativeProvider
+        set(value) {
+            oauthNativeProvider = value
+        }
 }
 
 /**
@@ -192,7 +202,7 @@ class DescopeFlow {
  *
  *     val descopeFlow = DescopeFlow("https://example.com")
  *     // set the OAuth provider ID that is configured to "sign in with Google"
- *     descopeFlow.oauthProvider = OAuthProvider.Google
+ *     descopeFlow.oauthNativeProvider = OAuthProvider.Google
  *     // set the oauth redirect URI to use your app's deep link
  *     descopeFlow.oauthRedirect = "my-redirect-deep-link"
  *     // customize the flow presentation further


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/8474

## Description

Rename `oauthProvider` to `nativeOAuthProvider` for clarity.
The former left in as deprecated.

## Must

-   [x] Tests
-   [x] Documentation (if applicable)
