### PR TITLE
Ensure browser app is available before launching custom tab

### DIFF
--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -186,8 +186,12 @@ class DescopeFlowCoordinator(val webView: WebView) {
                 return when (listener?.onNavigation(uri) ?: OpenBrowser) {
                     Inline -> false
                     DoNothing -> true
-                    OpenBrowser -> {
-                        launchCustomTab(webView.context, uri, flow.presentation?.createCustomTabsIntent(webView.context))
+                    OpenBrowser -> { 
+                        try {
+                            launchCustomTab(webView.context, uri, flow.presentation?.createCustomTabsIntent(webView.context))
+                        } catch (e: DescopeException) {
+                            logger?.log(Error, "Failed to open URL in browser", e)
+                        }
                         true
                     }
                 }


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/9589

## Description
- Ensure browser app is available before launching custom tab

## Must
- [X] Tests
- [X] Documentation (if applicable)
