### PR TITLE
Add support for triggering DescopeFlow failures or cancellations from the flow page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ written for Android. You can read more on the [Descope Website](https://descope.
 Add the following to your `build.gradle` dependencies:
 
 ```groovy
-implementation 'com.descope:descope-kotlin:0.14.0'
+implementation 'com.descope:descope-kotlin:0.14.1'
 ```
 
 ## Quickstart

--- a/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
@@ -76,6 +76,6 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         const val NAME = "DescopeAndroid"
 
         /** The Descope SDK version */
-        const val VERSION = "0.14.0"
+        const val VERSION = "0.14.1"
     }
 }

--- a/descopesdk/src/main/java/com/descope/types/Error.kt
+++ b/descopesdk/src/main/java/com/descope/types/Error.kt
@@ -106,6 +106,7 @@ class DescopeException(
         val enchantedLinkExpired = DescopeException(code = "K060001", desc = "Enchanted link expired")
 
         val flowFailed = DescopeException(code = "K100001", desc = "Flow failed to run")
+        val flowCancelled = DescopeException(code = "K100002", desc = "Flow cancelled")
 
         val passkeyFailed = DescopeException(code = "K110001", desc = "Passkey authentication failed")
         val passkeyCancelled = DescopeException(code = "K110002", desc = "Passkey authentication cancelled")


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/10134

## Description
- Allow triggering `DescopeFlow` failures or cancellations by calling `window.descopeBridge.abortFlow('reason')` in the flow page

## Must
- [X] Tests
- [X] Documentation (if applicable)
