### PR TITLE
Refactor DescopeLogger to support explicit unsafe logging flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ override fun onCreate() {
         baseUrl = "https://my.app.com"
         // enable the logger
         if (BuildConfig.DEBUG) {
-            logger = DescopeLogger()
+            logger = DescopeLogger.debugLogger
         }
     }
 }

--- a/descopesdk/src/main/java/com/descope/Descope.kt
+++ b/descopesdk/src/main/java/com/descope/Descope.kt
@@ -39,7 +39,7 @@ object Descope {
      *     Descope.setup(applicationContext, projectId = "DESCOPE_PROJECT_ID") {
      *         baseUrl = "https://my.app.com"
      *         if (BuildConfig.DEBUG) {
-     *             logger = DescopeLogger()
+     *             logger = DescopeLogger.debugLogger
      *         }
      *     }
      *      

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -33,6 +33,9 @@ import com.descope.internal.http.REFRESH_COOKIE_NAME
 import com.descope.internal.http.SESSION_COOKIE_NAME
 import com.descope.internal.http.failureFromResponseCode
 import com.descope.internal.others.activityHelper
+import com.descope.internal.others.debug
+import com.descope.internal.others.error
+import com.descope.internal.others.info
 import com.descope.internal.others.with
 import com.descope.internal.routes.convert
 import com.descope.internal.routes.getPackageOrigin
@@ -40,9 +43,6 @@ import com.descope.internal.routes.nativeAuthorization
 import com.descope.internal.routes.performAssertion
 import com.descope.internal.routes.performRegister
 import com.descope.sdk.DescopeLogger
-import com.descope.sdk.DescopeLogger.Level.Debug
-import com.descope.sdk.DescopeLogger.Level.Error
-import com.descope.sdk.DescopeLogger.Level.Info
 import com.descope.sdk.DescopeSdk
 import com.descope.session.Token
 import com.descope.types.DescopeException
@@ -74,10 +74,10 @@ class DescopeFlowCoordinator(val webView: WebView) {
             @JavascriptInterface
             fun onReady(tag: String) {
                 if (state != Started) {
-                    logger?.log(Debug, "Flow onReady called in state $state - ignoring")
+                    logger.debug("Flow onReady called in state $state - ignoring")
                     return
                 }
-                logger?.log(Info, "Flow is ready ($tag)")
+                logger.info("Flow is ready ($tag)")
                 handler.post {
                     handleReady()
                     listener?.onReady()
@@ -87,7 +87,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
             @JavascriptInterface
             fun onSuccess(success: String, url: String) {
                 if (state != Ready) {
-                    logger?.log(Debug, "Flow onSuccess called in state $state - ignoring")
+                    logger.debug("Flow onSuccess called in state $state - ignoring")
                     return
                 }
                 val jwtServerResponse = JwtServerResponse.fromJson(success, emptyList())
@@ -97,12 +97,12 @@ class DescopeFlowCoordinator(val webView: WebView) {
                 jwtServerResponse.refreshJwt = jwtServerResponse.refreshJwt ?: findJwtInCookies(cookieString, name = REFRESH_COOKIE_NAME)
                 handler.post {
                     state = Finished
-                    logger?.log(Info, "Flow finished successfully")
+                    logger.info("Flow finished successfully")
                     try {
                         val authResponse = jwtServerResponse.convert()
                         listener?.onSuccess(authResponse)
                     } catch (e: DescopeException) {
-                        logger?.log(Error, "Failed to parse authentication response", e)
+                        logger.error("Failed to parse authentication response", e)
                         listener?.onError(e)
                     }
                 }
@@ -111,16 +111,16 @@ class DescopeFlowCoordinator(val webView: WebView) {
             @JavascriptInterface
             fun onAbort(reason: String) {
                 if (state != Started && state != Ready) {
-                    logger?.log(Debug, "Flow onAbort called in state $state - ignoring")
+                    logger.debug("Flow onAbort called in state $state - ignoring")
                     return
                 }
                 handler.post {
                     state = Failed
                     if (reason.isEmpty()) {
-                        logger?.log(Info, "Flow aborted with cancellation")
+                        logger.info("Flow aborted with cancellation")
                         listener?.onError(DescopeException.flowCancelled)
                     } else {
-                        logger?.log(Error, "Flow aborted with a failure", reason)
+                        logger.error("Flow aborted with a failure", reason)
                         listener?.onError(DescopeException.flowFailed.with(message = reason))
                     }
                 }
@@ -129,12 +129,12 @@ class DescopeFlowCoordinator(val webView: WebView) {
             @JavascriptInterface
             fun onError(error: String) {
                 if (state != Ready) {
-                    logger?.log(Debug, "Flow onError called in state $state - ignoring")
+                    logger.debug("Flow onError called in state $state - ignoring")
                     return
                 }
                 handler.post {
                     state = Failed
-                    logger?.log(Error, "Flow finished with an exception", error)
+                    logger.error("Flow finished with an exception", error)
                     listener?.onError(DescopeException.flowFailed.with(desc = error))
                 }
             }
@@ -142,13 +142,13 @@ class DescopeFlowCoordinator(val webView: WebView) {
             @JavascriptInterface
             fun native(response: String?, url: String) {
                 if (response == null) {
-                    logger?.log(Info, "Skipping bridge call because response is null")
+                    logger.info("Skipping bridge call because response is null")
                     return
                 }
                 currentFlowUrl = url.toUri()
                 val scope = webView.findViewTreeLifecycleOwner()?.lifecycleScope
                 if (scope == null) {
-                    logger?.log(Error, "Unable to find lifecycle owner coroutine scope")
+                    logger.error("Unable to find lifecycle owner coroutine scope")
                     return
                 }
                 scope.launch(Dispatchers.Main) {
@@ -160,7 +160,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
                         type = nativePayload.type
                         when (nativePayload) {
                             is NativePayload.OAuthNative -> {
-                                logger?.log(Info, "Launching system UI for native oauth")
+                                logger.info("Launching system UI for native oauth")
                                 val resp = nativeAuthorization(webView.context, nativePayload.start)
                                 nativeResponse.put("nativeOAuth", JSONObject().apply {
                                     put("stateId", resp.stateId)
@@ -169,26 +169,26 @@ class DescopeFlowCoordinator(val webView: WebView) {
                             }
 
                             is NativePayload.OAuthWeb -> {
-                                logger?.log(Info, "Launching custom tab for web-based oauth")
+                                logger.info("Launching custom tab for web-based oauth")
                                 launchCustomTab(webView.context, nativePayload.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
                                 return@launch
                             }
 
                             is NativePayload.Sso -> {
-                                logger?.log(Info, "Launching custom tab for sso")
+                                logger.info("Launching custom tab for sso")
                                 launchCustomTab(webView.context, nativePayload.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
                                 return@launch
                             }
 
                             is NativePayload.WebAuthnCreate -> {
-                                logger?.log(Info, "Attempting to create new a passkey")
+                                logger.info("Attempting to create new a passkey")
                                 nativeResponse.put("transactionId", nativePayload.transactionId)
                                 val res = performRegister(webView.context, nativePayload.options)
                                 nativeResponse.put("response", res)
                             }
 
                             is NativePayload.WebAuthnGet -> {
-                                logger?.log(Info, "Attempting to use an existing passkey")
+                                logger.info("Attempting to use an existing passkey")
                                 nativeResponse.put("transactionId", nativePayload.transactionId)
                                 val res = performAssertion(webView.context, nativePayload.options)
                                 nativeResponse.put("response", res)
@@ -198,33 +198,33 @@ class DescopeFlowCoordinator(val webView: WebView) {
                         type = "failure"
                         val failure = when (e) {
                             DescopeException.oauthNativeCancelled -> {
-                                logger?.log(Info, "OAuth native canceled" )
+                                logger.info("OAuth native canceled" )
                                 canceled = true
                                 "OAuthNativeCancelled"
                             }
                             DescopeException.oauthNativeFailed -> {
-                                logger?.log(Error, "OAuth native failed", e)
+                                logger.error("OAuth native failed", e)
                                 "OAuthNativeFailed"
                             }
                             DescopeException.passkeyCancelled -> {
-                                logger?.log(Info, "Passkeys canceled")
+                                logger.info("Passkeys canceled")
                                 canceled = true
                                 "PasskeyCanceled"
                             }
                             DescopeException.passkeyFailed -> {
-                                logger?.log(Error, "Passkeys failed", e)
+                                logger.error("Passkeys failed", e)
                                 "PasskeyFailed"
                             }
                             DescopeException.passkeyNoPasskeys -> {
-                                logger?.log(Error, "No passkeys are available", e)
+                                logger.error("No passkeys are available", e)
                                 "PasskeyNoPasskeys"
                             }
                             DescopeException.customTabFailed -> {
-                                logger?.log(Error, "Failed to launch custom tab", e)
+                                logger.error("Failed to launch custom tab", e)
                                 "CustomTabFailure"
                             }
                             else -> {
-                                logger?.log(Error, "Native execution failed", e)
+                                logger.error("Native execution failed", e)
                                 "NativeFailed"
                             }
                         }
@@ -242,7 +242,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
             override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
                 val uri = request?.url ?: return false
                 if (request.isRedirect) return false
-                logger?.log(Info, "Flow attempting to navigate to a URL", uri)
+                logger.info("Flow attempting to navigate to a URL", uri)
                 return when (listener?.onNavigation(uri) ?: OpenBrowser) {
                     Inline -> false
                     DoNothing -> true
@@ -250,7 +250,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
                         try {
                             launchCustomTab(webView.context, uri, flow?.presentation?.createCustomTabsIntent(webView.context))
                         } catch (e: DescopeException) {
-                            logger?.log(Error, "Failed to open URL in browser", e)
+                            logger.error("Failed to open URL in browser", e)
                         }
                         true
                     }
@@ -258,13 +258,13 @@ class DescopeFlowCoordinator(val webView: WebView) {
             }
 
             override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                logger?.log(Info, "On page started", url)
+                logger.info("On page started", url)
             }
 
             override fun onPageFinished(view: WebView?, url: String?) {
-                logger?.log(Info, "On page finished", url, view?.progress)
+                logger.info("On page finished", url, view?.progress)
                 if (alreadySetUp) {
-                    logger?.log(Error, "Bridge is already set up", url, view?.progress)
+                    logger.error("Bridge is already set up", url, view?.progress)
                     return
                 }
                 alreadySetUp = true
@@ -288,7 +288,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
 
             override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
                 if (request?.isForMainFrame == true) {
-                    logger?.log(Error, "Error loading flow page", error?.errorCode, error?.description)
+                    logger.error("Error loading flow page", error?.errorCode, error?.description)
                     val code = error?.errorCode ?: 0
                     val failure = error?.description?.toString() ?: ""
                     val message = when (code) {
@@ -304,7 +304,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
 
             override fun onReceivedHttpError(view: WebView?, request: WebResourceRequest?, errorResponse: WebResourceResponse?) {
                 if (request?.isForMainFrame == true) {
-                    logger?.log(Error, "Flow page failed to load", errorResponse?.statusCode)
+                    logger.error("Flow page failed to load", errorResponse?.statusCode)
                     val statusCode = errorResponse?.statusCode ?: 0
                     val message = failureFromResponseCode(statusCode)
                     val exception = DescopeException.networkError.with(message = message)
@@ -350,7 +350,7 @@ document.head.appendChild(element)
 
     internal fun resumeFromDeepLink(deepLink: Uri) {
         if (flow == null) {
-            logger?.log(Error, "resumeFromDeepLink cannot be called before startFlow")
+            logger.error("resumeFromDeepLink cannot be called before startFlow")
             return
         }
         activityHelper.closeCustomTab(webView.context)
@@ -386,11 +386,11 @@ document.head.appendChild(element)
 
     private fun handleLoadError(exception: DescopeException) {
         if (state != Started) {
-            logger?.log(Debug, "Flow onLoadError called in state $state - ignoring")
+            logger.debug("Flow onLoadError called in state $state - ignoring")
             return
         }
         state = Failed
-        logger?.log(Error, "Flow failed to load", exception)
+        logger.error("Flow failed to load", exception)
         listener?.onError(exception)
     }
 

--- a/descopesdk/src/main/java/com/descope/internal/http/ClientErrors.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/ClientErrors.kt
@@ -5,14 +5,16 @@ import com.descope.internal.others.with
 import com.descope.types.DescopeException
 import org.json.JSONObject
 
-internal fun parseServerError(response: String): DescopeException? = try {
-    val map = JSONObject(response).toMap()
-    val code = map["errorCode"] as? String ?: throw Exception("errorCode is required")
-    val desc = map["errorDescription"] as? String ?: "Descope server error"
-    val message = map["errorMessage"] as? String
-    DescopeException(code = code, desc = desc, message = message)
-} catch (_: Exception) {
-    null
+internal fun parseServerError(response: String): DescopeException? {
+    try {
+        val map = JSONObject(response).toMap()
+        val code = map["errorCode"] as? String ?: return null
+        val desc = map["errorDescription"] as? String ?: "Descope server error"
+        val message = map["errorMessage"] as? String
+        return DescopeException(code = code, desc = desc, message = message)
+    } catch (_: Exception) {
+        return null
+    }
 }
 
 internal fun exceptionFromResponseCode(code: Int): DescopeException? {

--- a/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -3,6 +3,7 @@ package com.descope.internal.http
 import com.descope.sdk.DescopeConfig
 import com.descope.sdk.DescopeSdk
 import com.descope.types.DeliveryMethod
+import com.descope.types.DescopeException
 import com.descope.types.OAuthProvider
 import com.descope.types.RevokeType
 import com.descope.types.RevokeType.AllSessions
@@ -503,7 +504,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     override val defaultHeaders: Map<String, String> = makeDefaultHeaders(config, systemInfo)
         
-    override fun exceptionFromResponse(response: String): Exception? = parseServerError(response)
+    override fun exceptionFromResponse(response: String): DescopeException? = parseServerError(response)
 
     // Internal
 

--- a/descopesdk/src/main/java/com/descope/internal/others/Logger.kt
+++ b/descopesdk/src/main/java/com/descope/internal/others/Logger.kt
@@ -1,0 +1,41 @@
+package com.descope.internal.others
+
+import com.descope.sdk.DescopeLogger
+import com.descope.sdk.DescopeSdk
+
+internal val DescopeLogger?.isUnsafeEnabled
+    get() = this?.unsafe == true
+
+internal fun DescopeLogger?.error(message: String, vararg values: Any?) {
+    this?.log(DescopeLogger.Level.Error, message, *values)
+}
+
+internal fun DescopeLogger?.info(message: String, vararg values: Any?) {
+    this?.log(DescopeLogger.Level.Info, message, *values)
+}
+
+internal fun DescopeLogger?.debug(message: String, vararg values: Any?) {
+    this?.log(DescopeLogger.Level.Debug, message, *values)
+}
+
+internal open class ConsoleLogger(level: Level, unsafe: Boolean) : DescopeLogger(level, unsafe) {
+    override fun output(level: Level, message: String, values: List<Any>) {
+        var text = "[${DescopeSdk.NAME}] $message"
+        if (values.isNotEmpty()) {
+            text += """ (${values.joinToString(", ") { v -> v.toString() }})"""
+        }
+        println(text)
+    }
+    
+    companion object {
+        val basic: ConsoleLogger = ConsoleLogger(level = Level.Info, unsafe = false)
+        
+        val debug: ConsoleLogger = object : ConsoleLogger(level = Level.Debug, unsafe = false) {
+            override val unsafe: Boolean get() = isApplicationDebuggable
+        }
+        
+        val unsafe: ConsoleLogger = ConsoleLogger(level = Level.Debug, unsafe = true)
+
+        var isApplicationDebuggable = false
+    }
+}

--- a/descopesdk/src/main/java/com/descope/sdk/Config.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Config.kt
@@ -1,5 +1,6 @@
 package com.descope.sdk
 
+import com.descope.internal.others.ConsoleLogger
 import java.net.URL
 
 /**
@@ -10,12 +11,35 @@ import java.net.URL
 class DescopeConfig(val projectId: String) {
     /** An optional override for the base URL of the Descope server. */
     var baseUrl: String? = null
+    
     /**
-     * An optional logger to use for logging messages in the Descope SDK.
-     * - _**IMPORTANT**: Logging is intended for `DEBUG` only. Do not enable logs when building
-     * the `RELEASE` versions of your application._
+     * An optional object to handle logging in the Descope SDK.
+     *
+     * The default value of this property is `null` and thus logging will be completely
+     * disabled. You can set this to [DescopeLogger.basicLogger] to print error and info
+     * log messages to the console.
+     *
+     * If you encounter any issues you can also use [DescopeLogger.debugLogger] to enable
+     * more verbose logging. This will configure a simple logger that prints all logs to the
+     * console. If the logger detects that the app is was built for debugging (i.e., the build
+     * config has the `debuggable` flag) it will also output potentially sensitive runtime values,
+     * such as full network request and response payloads, secrets and tokens in cleartext, etc.
+     *
+     *     Descope.setup(this, projectId = "...") {
+     *         logger = DescopeLogger.debugLogger
+     *     }
+     *
+     * In rare cases you might need to use [DescopeLogger.unsafeLogger] which skips the
+     * debuggable flag check and always prints all log data including all sensitive runtime
+     * values. Make sure you don't use [DescopeLogger.unsafeLogger] in release builds
+     * intended for production.
+     *
+     * If your application uses some logging framework or third party service you can forward
+     * the Descope SDK log messages to it by subclassing [DescopeLogger] and overriding
+     * the `output` method. See the documentation for [DescopeLogger] for more details.
      */
     var logger: DescopeLogger? = null
+    
     /**
      * An optional object to override how HTTP requests are performed.
      *  - The default value of this property is always `null`, and the SDK uses its own
@@ -27,51 +51,80 @@ class DescopeConfig(val projectId: String) {
     var networkClient: DescopeNetworkClient? = null
 }
 
-/** 
- * _**IMPORTANT**: Logging is intended for `DEBUG` only. Do not enable logs when building
- * the `RELEASE` versions of your application._
+/**
+ * The [DescopeLogger] class can be used if you need to customize how logging works in the
+ * Descope SDK, but in most cases you can simply use [DescopeLogger.debugLogger] (see the
+ * documentation for the `logger` property in [DescopeConfig] for more details).
+ *
+ * Create a subclass of [DescopeLogger] and override the [output] method. See the documentation
+ * for that method for more details.
+ *
+ *     Descope.setup(this, projectId = "...") {
+ *         logger = RemoteDescopeLogger()
+ *     }
+ *
+ *     // elsewhere
+ *
+ *     class RemoveDescopeLogger: DescopeLogger(level = Level.Info, unsafe = false) {
+ *         override fun output(level: Level, message: String, values: List<Any>) {
+ *             RemoveLogger.sendLog("Descope: $message")
+ *         }
+ *     }
+ *
+ * The logging functions might be called concurrently on multiple threads, so you
+ * should make sure your subclass implementation is thread safe.
  * 
- * The [DescopeLogger] class can be used to customize logging functionality in the Descope SDK.
- *
- * The default behavior is for log messages to be written to the standard output using
- * the `println()` function.
- *
- * You can also customize how logging functions in the Descope SDK by creating a subclass
- * of [DescopeLogger] and overriding the [DescopeLogger.output] method. See the
- * documentation for that method for more details.
+ * @param level The maximum log level that should be printed.
+ * @param unsafe Whether to print unsafe runtime value.
  */
-open class DescopeLogger(private val level: Level = Level.Debug) {
+open class DescopeLogger(open val level: Level, open val unsafe: Boolean) {
+    /** Built-in console loggers for use during development. */
+    companion object {
+        /**
+         * A simple logger that prints basic error and info logs using `println`.
+         */
+        val basicLogger: DescopeLogger = ConsoleLogger.basic
 
+        /**
+         * A simple logger that prints all logs using `println`, but does not output any
+         * potentially unsafe runtime values unless a debugger is attached.
+         */
+        val debugLogger: DescopeLogger = ConsoleLogger.debug
+
+        /**
+         * A simple logger that prints all logs using `println`, including potentially unsafe
+         * runtime values such as secrets, personal information, network payloads, etc.
+         * 
+         * - **IMPORTANT**: Do not use unsafeLogger in release builds intended for production.
+         */
+        val unsafeLogger: DescopeLogger = ConsoleLogger.unsafe
+    }
+    
     /** The severity of a log message. */
     enum class Level {
         Error, Info, Debug
     }
     
-    internal var isDebug: Boolean = false
-
-    /**
-     * Formats the log message and prints it.
-     *
-     * Override this method to customize how to handle log messages from the Descope SDK.
-     *
-     * @param level the log level printed
-     * @param message the message to print
-     * @param values any associated values. _**IMPORTANT** - sensitive information may be printed here. Enable logs only when debugging._
-     */
-    open fun output(level: Level, message: String, vararg values: Any?) {
-        var text = "[${DescopeSdk.NAME}] $message"
-        val filtered = values.filterNotNull()
-        if (filtered.isNotEmpty()) {
-            text += """ (${filtered.joinToString(", ") { v -> v.toString() }})"""
-        }
-        println(text);
-    }
-
-    // Called by other code in the Descope SDK to output log messages.
+    /** Called by other code in the Descope SDK to output log messages. */
     fun log(level: Level, message: String, vararg values: Any?) {
         if (level > this.level) return
-        output(level, message, *(if (isDebug) values else emptyArray()))
-    }   
+        val filtered = if (unsafe) values.filterNotNull() else emptyList()
+        output(level, message, filtered)
+    }
+
+    /**
+     * Override this method to implement formatting and printing of logs from the Descope SDK.
+     *
+     * @param level the log level of the message.
+     * @param message the log message is guaranteed to be a plain string that's safe for logging. You can
+     * assume it doesn't contain any secrets, user data, or personal information and that it can be safely
+     * printed or sent to a third party logging service.
+     * @param values this array has runtime values that might be useful when debugging issues with
+     * the Descope SDK. As these values are not considered safe this array is always empty unless
+     * the logger was created with [unsafe] set to `true`.
+     */
+    open fun output(level: Level, message: String, values: List<Any>) {
+    }
 }
 
 /**

--- a/descopesdk/src/main/java/com/descope/sdk/Config.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Config.kt
@@ -125,6 +125,9 @@ open class DescopeLogger(open val level: Level, open val unsafe: Boolean) {
      */
     open fun output(level: Level, message: String, values: List<Any>) {
     }
+    
+    @Deprecated(message = "Use DescopeLogger.basicLogger or DescopeLogger.debugLogger to diagnose issues during development")
+    constructor(level: Level = Level.Debug) : this(level, false)
 }
 
 /**

--- a/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
@@ -7,6 +7,7 @@ import android.content.pm.ApplicationInfo
 import android.os.Looper
 import com.descope.internal.http.DescopeClient
 import com.descope.internal.http.DescopeSystemInfo
+import com.descope.internal.others.ConsoleLogger
 import com.descope.internal.routes.Auth
 import com.descope.internal.routes.EnchantedLink
 import com.descope.internal.routes.Flow
@@ -44,7 +45,8 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         // init config
         val config = DescopeConfig(projectId = projectId)
         configure(config)
-        config.logger?.isDebug = context.applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+        // init logging debug flag
+        ConsoleLogger.isApplicationDebuggable = context.applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
         // init auth methods
         client = DescopeClient(config, DescopeSystemInfo.getInstance(context))
         auth = Auth(client)

--- a/descopesdk/src/main/java/com/descope/session/Lifecycle.kt
+++ b/descopesdk/src/main/java/com/descope/session/Lifecycle.kt
@@ -3,11 +3,11 @@ package com.descope.session
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.descope.internal.others.debug
+import com.descope.internal.others.error
+import com.descope.internal.others.info
 import com.descope.sdk.DescopeAuth
 import com.descope.sdk.DescopeLogger
-import com.descope.sdk.DescopeLogger.Level.Debug
-import com.descope.sdk.DescopeLogger.Level.Error
-import com.descope.sdk.DescopeLogger.Level.Info
 import com.descope.types.DescopeException
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -72,7 +72,7 @@ class SessionLifecycle(
 
             field = value
             if (value != null && value.refreshToken.isExpired) {
-                logger?.log(Info, "Session has an expired refresh token", value.refreshToken.expiresAt)
+                logger.info("Session has an expired refresh token", value.refreshToken.expiresAt)
             }
             resetTimer()
         }
@@ -83,10 +83,10 @@ class SessionLifecycle(
             return false
         }
         
-        logger?.log(Info, "Refreshing session that is about to expire", current.sessionToken.expiresAt)
+        logger.info("Refreshing session that is about to expire", current.sessionToken.expiresAt)
         val response = auth.refreshSession(current.refreshJwt)
         if (session?.sessionJwt != current.sessionJwt) {
-            logger?.log(Info, "Skipping refresh because session has changed in the meantime")
+            logger.info("Skipping refresh because session has changed in the meantime")
             return false
         }
         
@@ -134,7 +134,7 @@ class SessionLifecycle(
         val refreshToken = session?.refreshToken
 
         if (refreshToken == null || refreshToken.isExpired) {
-            logger?.log(Debug, "Stopping periodic refresh for session with expired refresh token")
+            logger.debug("Stopping periodic refresh for session with expired refresh token")
             stopTimer()
             return
         }
@@ -142,18 +142,18 @@ class SessionLifecycle(
         try {
             val refreshed = refreshSessionIfNeeded()
             if (refreshed) {
-                logger?.log(Debug, "Saving refresh session after periodic refresh")
+                logger.debug("Saving refresh session after periodic refresh")
                 onPeriodicRefresh?.invoke()
             }
         } catch (e: DescopeException) {
             if (e == DescopeException.networkError) {
-                logger?.log(Debug, "Ignoring network error in periodic refresh")
+                logger.debug("Ignoring network error in periodic refresh")
             } else {
-                logger?.log(Error, "Stopping periodic refresh after failure", e)
+                logger.error("Stopping periodic refresh after failure", e)
                 stopTimer()
             }
         } catch (e: Exception) {
-            logger?.log(Error, "Stopping periodic refresh after unexpected failure", e)
+            logger.error("Stopping periodic refresh after unexpected failure", e)
             stopTimer()
         }
     }

--- a/descopesdk/src/main/java/com/descope/session/Storage.kt
+++ b/descopesdk/src/main/java/com/descope/session/Storage.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.net.Uri
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import com.descope.internal.others.debug
+import com.descope.internal.others.error
 import com.descope.internal.others.optionalMap
 import com.descope.internal.others.stringOrEmptyAsNull
 import com.descope.internal.others.toJsonArray
@@ -11,8 +13,6 @@ import com.descope.internal.others.toJsonObject
 import com.descope.internal.others.toStringList
 import com.descope.internal.others.tryOrNull
 import com.descope.sdk.DescopeLogger
-import com.descope.sdk.DescopeLogger.Level.Debug
-import com.descope.sdk.DescopeLogger.Level.Error
 import com.descope.types.DescopeUser
 import org.json.JSONObject
 
@@ -211,15 +211,15 @@ private fun DescopeUser.toJson() = JSONObject().apply {
 private fun createEncryptedStore(context: Context, projectId: String, logger: DescopeLogger?): SessionStorage.Store {
     try {
         val storage = EncryptedSharedPrefs(projectId, context)
-        logger?.log(Debug, "Encrypted storage initialized successfully")
+        logger.debug("Encrypted storage initialized successfully")
         return storage
     } catch (e: Exception) {
         try {
-            logger?.log(Error, "Encrypted storage key unusable")
+            logger.error("Encrypted storage key unusable")
             context.deleteSharedPreferences(projectId)
             return EncryptedSharedPrefs(projectId, context)
         } catch (e: Exception) {
-            logger?.log(Error, "Unable to initialize encrypted storage", e)
+            logger.error("Unable to initialize encrypted storage", e)
             return SessionStorage.Store.none
         }
     }


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/10329

## Description
- Add built-in loggers `DescopeLogger.basicLogger` and `DescopeLogger.debugLogger` for common case of wanting to see logs in the console during app development.
- Refactor `DescopeLogger` to support explicit `unsafe` logging flag.
- Improve error logs by always printing some runtime value that are guaranteed to be safe such as error codes and URL routes are always sent in logs.

## Must
- [X] Tests
- [X] Documentation (if applicable)
