### PR TITLE
Session provider for flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ written for Android. You can read more on the [Descope Website](https://descope.
 Add the following to your `build.gradle` dependencies:
 
 ```groovy
-implementation 'com.descope:descope-kotlin:0.15.0'
+implementation 'com.descope:descope-kotlin:0.16.0'
 ```
 
 ## Quickstart

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
@@ -31,34 +31,34 @@ class DescopeFlow {
     var hooks: List<DescopeFlowHook> = emptyList()
 
     /**
-     *  An object that provides the [DescopeSession] value for the currently authenticated
-     *  user if there is one, or `null` otherwise.
-     * 
-     *  This is used when running a flow that expects the user to already be signed in.
-     *  For example, a flow to update a user's email or account recovery details, or that
-     *  does step-up authentication.
-     * 
-     *  The default behavior is to check whether the [DescopeSessionManager] is currently
-     *  managing a valid session, and return it if that's the case.
-     * 
-     *  - Note: The default behavior checks the [DescopeSessionManager] from the [Descope]
-     *  singleton, or the one from the flow's [sdk] property if it is set.
-     * 
-     *  If you're not using the [DescopeSessionManager] but rather managing the tokens
-     *  manually, and if you also need to start a flow for an authenticated user, then you
-     *  should set your own [sessionProvider]. For example:
-     *  
-     *      // create a flow object with the URL where the flow is hosted
-     *      val flow = DescopeFlow("https://example.com/myflow")
-     *     
-     *      // fetch the latest session from our model layer when needed
-     *      flow.sessionProvider = {
-     *          return modelLayer.fetchDescopeSession()
-     *      }
-     *  
-     *  - **Important**: The provider may be called multiple times to ensure that the flow uses
-     *  the newest tokens, even if the session is refreshed while the flow is running.
-     *  This is especially important for projects that use refresh token rotation.
+     * An object that provides the [DescopeSession] value for the currently authenticated
+     * user if there is one, or `null` otherwise.
+     *
+     * This is used when running a flow that expects the user to already be signed in.
+     * For example, a flow to update a user's email or account recovery details, or that
+     * does step-up authentication.
+     *
+     * The default behavior is to check whether the [DescopeSessionManager] is currently
+     * managing a valid session, and return it if that's the case.
+     *
+     * - **Note**: The default behavior checks the [DescopeSessionManager] from the [Descope]
+     * singleton, or the one from the flow's [sdk] property if it is set.
+     *
+     * If you're not using the [DescopeSessionManager] but rather managing the tokens
+     * manually, and if you also need to start a flow for an authenticated user, then you
+     * should set your own [sessionProvider]. For example:
+     *
+     *     // create a flow object with the URL where the flow is hosted
+     *     val flow = DescopeFlow("https://example.com/myflow")
+     *
+     *     // fetch the latest session from our model layer when needed
+     *     flow.sessionProvider = {
+     *         return modelLayer.fetchDescopeSession()
+     *     }
+     *
+     * - **Important**: The provider may be called multiple times to ensure that the flow uses
+     * the newest tokens, even if the session is refreshed while the flow is running.
+     * This is especially important for projects that use refresh token rotation.
      */ 
     var sessionProvider: (() -> DescopeSession?)? = null
 

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
@@ -6,6 +6,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import com.descope.Descope
 import com.descope.sdk.DescopeSdk
 import com.descope.session.DescopeSession
+import com.descope.session.DescopeSessionManager
 import com.descope.types.OAuthProvider
 
 /**
@@ -30,13 +31,36 @@ class DescopeFlow {
     var hooks: List<DescopeFlowHook> = emptyList()
 
     /**
-     * An optional [DescopeSession] to start a flow for an authenticated user.
+     *  An object that provides the [DescopeSession] value for the currently authenticated
+     *  user if there is one, or `null` otherwise.
      * 
-     * This can be used when running a flow that expects the user to already be signed in
-     * or that does step-up authentication. For example, a flow to update a user’s email
-     * or account recovery details.
+     *  This is used when running a flow that expects the user to already be signed in.
+     *  For example, a flow to update a user's email or account recovery details, or that
+     *  does step-up authentication.
+     * 
+     *  The default behavior is to check whether the [DescopeSessionManager] is currently
+     *  managing a valid session, and return it if that's the case.
+     * 
+     *  - **Note**: The default provider uses either the [DescopeSessionManager] from the
+     *  [Descope] singleton, or the one from the [sdk] property if it is set.
+     * 
+     *  If you're not using the [DescopeSessionManager] but rather managing the tokens
+     *  manually, and if you also need to start a flow for an authenticated user, then you
+     *  should set your own [sessionProvider]. For example:
+     *  
+     *      // create a flow object with the URL where the flow is hosted
+     *      val flow = DescopeFlow("https://example.com/myflow")
+     *     
+     *      // fetch the latest session from our model layer when needed
+     *      flow.sessionProvider = {
+     *          return modelLayer.fetchDescopeSession()
+     *      }
+     *  
+     *  - **Important**: The provider may be called multiple times to ensure that the flow uses
+     *  the newest tokens, even if the session is refreshed while the flow is running.
+     *  This is especially important for projects that use refresh token rotation.
      */ 
-    var session: DescopeSession? = null
+    var sessionProvider: (() -> DescopeSession?)? = null
 
     /**
      * The ID of the oauth provider that is configured to natively "Sign In with Google".

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
@@ -41,8 +41,8 @@ class DescopeFlow {
      *  The default behavior is to check whether the [DescopeSessionManager] is currently
      *  managing a valid session, and return it if that's the case.
      * 
-     *  - **Note**: The default provider uses either the [DescopeSessionManager] from the
-     *  [Descope] singleton, or the one from the [sdk] property if it is set.
+     *  - Note: The default behavior checks the [DescopeSessionManager] from the [Descope]
+     *  singleton, or the one from the flow's [sdk] property if it is set.
      * 
      *  If you're not using the [DescopeSessionManager] but rather managing the tokens
      *  manually, and if you also need to start a flow for an authenticated user, then you

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -33,6 +33,7 @@ import com.descope.internal.http.REFRESH_COOKIE_NAME
 import com.descope.internal.http.SESSION_COOKIE_NAME
 import com.descope.internal.http.failureFromResponseCode
 import com.descope.internal.others.activityHelper
+import com.descope.internal.others.debug
 import com.descope.internal.others.error
 import com.descope.internal.others.info
 import com.descope.internal.others.isUnsafeEnabled
@@ -44,13 +45,19 @@ import com.descope.internal.routes.performAssertion
 import com.descope.internal.routes.performRegister
 import com.descope.sdk.DescopeLogger
 import com.descope.sdk.DescopeSdk
+import com.descope.session.DescopeSession
 import com.descope.session.Token
 import com.descope.types.AuthenticationResponse
 import com.descope.types.DescopeException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.json.JSONObject
+import java.lang.ref.WeakReference
 import java.net.HttpCookie
+import java.util.Timer
+import java.util.TimerTask
+import kotlin.concurrent.timer
 
 @SuppressLint("SetJavaScriptEnabled")
 class DescopeFlowCoordinator(val webView: WebView) {
@@ -64,6 +71,8 @@ class DescopeFlowCoordinator(val webView: WebView) {
         get() = flow?.sdk ?: if (Descope.isInitialized) Descope.sdk else null
     private val logger: DescopeLogger?
         get() = sdk?.client?.config?.logger
+    private val currentSession: DescopeSession?
+        get() = if (flow?.sessionProvider != null) flow?.sessionProvider?.invoke() else sdk?.sessionManager?.session
     private var currentFlowUrl: Uri? = null
     private var alreadySetUp = false
 
@@ -79,12 +88,19 @@ class DescopeFlowCoordinator(val webView: WebView) {
 
             @JavascriptInterface
             fun onSuccess(data: String?, url: String) {
-                val session = flow?.session
-                when {
-                    data != null -> handleAuthentication(data, url)
-                    session != null -> handleSuccess(AuthenticationResponse(sessionToken = session.sessionToken, refreshToken = session.refreshToken, user = session.user, isFirstAuthentication = false))
-                    else -> handleError(DescopeException.flowFailed.with(message = "No valid authentication tokens found"))
+                // in case we got an authentication response, use it
+                if (data != null) {
+                    handleAuthentication(data, url)
+                    return
                 }
+                // if we didn't, use the session if it's available
+                val session = currentSession
+                if (session != null) {
+                    handleSuccess(AuthenticationResponse(sessionToken = session.sessionToken, refreshToken = session.refreshToken, user = session.user, isFirstAuthentication = false))
+                    return
+                }
+                // onSuccess must end with a valid authentication response at this point in time
+                handleError(DescopeException.flowFailed.with(message = "No valid authentication tokens found"))
             }
 
             @JavascriptInterface
@@ -240,7 +256,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
                     val useCustomSchemeFallback = shouldUseCustomSchemeUrl(context)
                     evaluateJavascript(
                         setupScript(
-                            refreshJwt = flow?.session?.refreshJwt ?: "",
+                            refreshJwt = currentSession?.refreshJwt ?: "",
                             origin = origin,
                             oauthNativeProvider = flow?.oauthNativeProvider?.name ?: "",
                             oauthRedirect = pickRedirectUrl(flow?.oauthRedirect, flow?.oauthRedirectCustomScheme, useCustomSchemeFallback),
@@ -335,6 +351,12 @@ document.head.appendChild(element)
         hooks.filter { it.events.contains(event) }
             .forEach { it.execute(event, this) }
     }
+    
+    internal fun periodicRefreshJwtUpdate() {
+        handler.post {
+            webView.evaluateJavascript("flowBridgeSetRefreshJwt(null, '${currentSession?.refreshJwt?.escapeForBackticks() ?: ""}');") {}
+        }
+    }
 
     // Events
 
@@ -354,6 +376,7 @@ document.head.appendChild(element)
         if (ensureState(Started)) return
         handler.post {
             logger.info("Flow is ready ($tag)")
+            startTimer()
             state = Ready
             executeHooks(Event.Ready)
             listener?.onReady()
@@ -369,6 +392,7 @@ document.head.appendChild(element)
 
         handler.post {
             logger.error("Flow failed with ${e.code}) error", e)
+            stopTimer()
             state = Failed
             listener?.onError(e)
         }
@@ -379,6 +403,7 @@ document.head.appendChild(element)
         handler.post {
             val res = if (logger.isUnsafeEnabled) authResponse else null
             logger.info("Flow finished successfully", res)
+            stopTimer()
             state = Finished
             listener?.onSuccess(authResponse)
         }
@@ -392,6 +417,7 @@ document.head.appendChild(element)
             jwtServerResponse.sessionJwt = jwtServerResponse.sessionJwt ?: findJwtInCookies(cookieString, name = SESSION_COOKIE_NAME)
             jwtServerResponse.refreshJwt = jwtServerResponse.refreshJwt ?: findJwtInCookies(cookieString, name = REFRESH_COOKIE_NAME)
             val authResponse = jwtServerResponse.convert()
+            logger.debug("Flow received an authentication response", data)
             handleSuccess(authResponse)
         } catch (e: DescopeException) {
             logger.error("Unexpected error handling authentication response", e, data, url)
@@ -405,6 +431,24 @@ document.head.appendChild(element)
         }
         logger.error("Unexpected flow state: ${state.name}", allowedStates)
         return true
+    }
+    
+    // Timer
+
+    private val periodicUpdateFrequency: Long = 1000L // 1 second
+    private var timer: Timer? = null
+    
+    private fun startTimer() {
+        stopTimer()
+        
+        val ref = WeakReference(this)
+        val action = createTimerAction(ref)
+        timer = timer(name = "DescopeFlowCoordinator", period = periodicUpdateFrequency, action = action)
+    }
+    
+    private fun stopTimer() {
+        timer?.cancel()
+        timer = null
     }
 }
 
@@ -495,13 +539,21 @@ function flowBridgeIsReady(wc, tag) {
     flow.onReady(tag);
 }
 
-function flowBridgePrepareWebComponent(wc) {
-    const refreshJwt = '$refreshJwt';
+function flowBridgeSetRefreshJwt(wc, refreshJwt) {
+    wc = wc || document.getElementsByTagName('descope-wc')[0]
+    if (!wc) {
+        console.debug('Unable to set refresh token, web-component not found')
+        return
+    }
     if (refreshJwt) {
         const storagePrefix = wc.getAttribute('storage-prefix') || ''
         window.localStorage.setItem(storagePrefix + 'DSR', refreshJwt);
     }
-    
+}
+
+function flowBridgePrepareWebComponent(wc) {
+    flowBridgeSetRefreshJwt(wc, '$refreshJwt')
+      
     wc.nativeOptions = {
         bridgeVersion: 1,
         platform: 'android',
@@ -597,4 +649,15 @@ private fun pickRedirectUrl(main: String?, fallback: String?, useFallback: Boole
     var url = main
     if (useFallback && fallback != null) url = fallback
     return url ?: ""
+}
+
+private fun createTimerAction(ref: WeakReference<DescopeFlowCoordinator>): (TimerTask.() -> Unit) {
+    return {
+        val coordinator = ref.get()
+        if (coordinator == null) {
+            cancel()
+        } else {
+            coordinator.periodicRefreshJwtUpdate()
+        }
+    }
 }

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -72,7 +72,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
     private val logger: DescopeLogger?
         get() = sdk?.client?.config?.logger
     private val currentSession: DescopeSession?
-        get() = if (flow?.sessionProvider != null) flow?.sessionProvider?.invoke() else sdk?.sessionManager?.session
+        get() = if (flow?.sessionProvider != null) flow?.sessionProvider?.invoke() else sdk?.sessionManager?.session?.takeIf { !it.refreshToken.isExpired }
     private var currentFlowUrl: Uri? = null
     private var alreadySetUp = false
 

--- a/descopesdk/src/main/java/com/descope/internal/http/HttpClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/HttpClient.kt
@@ -65,7 +65,6 @@ internal open class HttpClient(
             putAll(headers)
         }
 
-        logger.info("Starting network call", url)
         if (logger.isUnsafeEnabled) {
             logger.info("Starting network call", url)
         } else {
@@ -76,7 +75,6 @@ internal open class HttpClient(
             val response = networkClient.sendRequest(url, method, body, combinedHeaders)
             if (response.code != HttpsURLConnection.HTTP_OK) {
                 exceptionFromResponse(response.body)?.let { e ->
-                    logger.error("Network call failed with server error", url, response.code, e)
                     if (logger.isUnsafeEnabled) {
                         logger.error("Network call failed with server error", url, e)
                     } else {

--- a/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
@@ -78,6 +78,6 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         const val NAME = "DescopeAndroid"
 
         /** The Descope SDK version */
-        const val VERSION = "0.15.0"
+        const val VERSION = "0.16.0"
     }
 }

--- a/descopesdk/src/main/java/com/descope/session/Manager.kt
+++ b/descopesdk/src/main/java/com/descope/session/Manager.kt
@@ -145,8 +145,17 @@ class DescopeSessionManager(
      * @param session the session to manage
      */
     fun manageSession(session: DescopeSession) {
+        val current = lifecycle.session
         lifecycle.session = session
         storage.saveSession(session)
+        // notify the listeners if the session has been updated
+        if (current == null) return
+        if (current.sessionJwt != session.sessionJwt || current.refreshJwt != session.refreshJwt) {
+            listeners.forEach { it.onUpdateTokens(session) }
+        }
+        if (current.user != session.user) {
+            listeners.forEach { it.onUpdateUser(session) }
+        }
     }
 
     /**

--- a/descopesdk/src/main/java/com/descope/session/Session.kt
+++ b/descopesdk/src/main/java/com/descope/session/Session.kt
@@ -173,7 +173,7 @@ class DescopeSession {
      *     // to this:
      *     val newSession = session.withUpdatedTokens(refreshResponse)
      */
-    @Deprecated(message = "Use withUpdatedTokens instead")
+    @Deprecated(message = "Use withUpdatedTokens instead", replaceWith = ReplaceWith("session.withUpdatedTokens"))
     fun updateTokens(refreshResponse: RefreshResponse) {
         sessionToken = refreshResponse.sessionToken
         refreshToken = refreshResponse.refreshToken ?: refreshToken
@@ -189,7 +189,7 @@ class DescopeSession {
      *     // to this:
      *     val newSession = session.withUpdatedUser(user)
      */
-    @Deprecated(message = "Use withUpdatedUser instead")
+    @Deprecated(message = "Use withUpdatedUser instead", replaceWith = ReplaceWith("session.withUpdatedUser"))
     fun updateUser(descopeUser: DescopeUser) {
         user = descopeUser
     }

--- a/descopesdk/src/main/java/com/descope/session/Session.kt
+++ b/descopesdk/src/main/java/com/descope/session/Session.kt
@@ -173,7 +173,7 @@ class DescopeSession {
      *     // to this:
      *     val newSession = session.withUpdatedTokens(refreshResponse)
      */
-    @Deprecated(message = "Use withUpdatedTokens instead", replaceWith = ReplaceWith("session.withUpdatedTokens"))
+    @Deprecated(message = "Use withUpdatedTokens instead")
     fun updateTokens(refreshResponse: RefreshResponse) {
         sessionToken = refreshResponse.sessionToken
         refreshToken = refreshResponse.refreshToken ?: refreshToken
@@ -189,7 +189,7 @@ class DescopeSession {
      *     // to this:
      *     val newSession = session.withUpdatedUser(user)
      */
-    @Deprecated(message = "Use withUpdatedUser instead", replaceWith = ReplaceWith("session.withUpdatedUser"))
+    @Deprecated(message = "Use withUpdatedUser instead")
     fun updateUser(descopeUser: DescopeUser) {
         user = descopeUser
     }

--- a/descopesdk/src/main/java/com/descope/session/Token.kt
+++ b/descopesdk/src/main/java/com/descope/session/Token.kt
@@ -194,7 +194,7 @@ private enum class Claim(val key: String) {
     Roles("roles");
 
     companion object {
-        fun isCustom(name: String): Boolean = Claim.values().find { it.key == name } == null
+        fun isCustom(name: String): Boolean = entries.find { it.key == name } == null
     }
 }
 


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/10526

## Description

- Change `DescopeFlow` implementation to receive a `sessionProvider` function to keep the flow updated with the current session, even if it refreshes in the meantime. `DescopeSessionManager` users get this behavior for free, but it can be overridden if implementing manual session management.
- Bump version to 0.16.0

## Must

-   [x] Tests
-   [x] Documentation (if applicable)
