### PR TITLE
Various fixes

### DIFF
--- a/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
@@ -114,6 +114,14 @@ class DescopeFlow {
     var magicLinkRedirect: String? = null
 
     /**
+     * An optional flag that indicates whether the flow should be reloaded
+     * if an error occurs while first trying to load it. Only a few attempts
+     * will be made in a short time frame, and if the flow still fails to load
+     * the [DescopeFlowView.Listener.onError] callback will be called with the error.
+     */
+    var reloadFlowOnError: Boolean = true
+
+    /**
      * Customize the [DescopeFlowView] presentation by providing a [Presentation] implementation
      */
     var presentation: Presentation? = null

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -49,8 +49,10 @@ import com.descope.session.DescopeSession
 import com.descope.session.Token
 import com.descope.types.AuthenticationResponse
 import com.descope.types.DescopeException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.lang.ref.WeakReference
@@ -127,11 +129,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
                     return
                 }
                 currentFlowUrl = url.toUri()
-                val scope = webView.findViewTreeLifecycleOwner()?.lifecycleScope
-                if (scope == null) {
-                    logger.error("Unable to find lifecycle owner coroutine scope")
-                    return
-                }
+                val scope = webView.findViewTreeLifecycleOwner()?.lifecycleScope ?: CoroutineScope(Job())
                 scope.launch(Dispatchers.Main) {
                     var type: String
                     var canceled = false

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -177,7 +177,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
                         type = "failure"
                         val failure = when (e) {
                             DescopeException.oauthNativeCancelled -> {
-                                logger.info("OAuth native canceled" )
+                                logger.info("OAuth native canceled")
                                 canceled = true
                                 "OAuthNativeCancelled"
                             }
@@ -389,9 +389,10 @@ document.head.appendChild(element)
         if (state == Failed) return
 
         handler.post {
-            logger.error("Flow failed with ${e.code}) error", e)
+            logger.error("Flow failed with [${e.code}] error", e)
             stopTimer()
             state = Failed
+            attempts = 0
             listener?.onError(e)
         }
     }

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -324,7 +324,7 @@ document.head.appendChild(element)
 
     // Internal API
 
-    internal fun run(flow: DescopeFlow) {
+    internal fun startFlow(flow: DescopeFlow) {
         this.flow = flow
         handleStarted()
         webView.loadUrl(flow.url)

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -398,7 +398,7 @@ document.head.appendChild(element)
     }
     
     private fun handleSuccess(authResponse: AuthenticationResponse) {
-        if (ensureState(Ready)) return
+        if (ensureState(Started, Ready)) return
         handler.post {
             val res = if (logger.isUnsafeEnabled) authResponse else null
             logger.info("Flow finished successfully", res)

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowView.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowView.kt
@@ -6,13 +6,10 @@ import android.util.AttributeSet
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.webkit.WebView
-import androidx.browser.customtabs.CustomTabsIntent
 import com.descope.Descope
-import com.descope.sdk.DescopeSdk
 import com.descope.session.DescopeSession
 import com.descope.types.AuthenticationResponse
 import com.descope.types.DescopeException
-import com.descope.types.OAuthProvider
 
 /**
  * Authenticate a user using Descope Flows.
@@ -135,15 +132,15 @@ class DescopeFlowView : ViewGroup {
     // API
 
     /**
-     * Run a flow based on the configuration provided
+     * Start a flow based on the configuration provided
      * via a [DescopeFlowView]
      *
      * @param flow The [DescopeFlow] to execute
      */
-    fun run(flow: DescopeFlow) {
-        flowCoordinator.run(flow)
+    fun startFlow(flow: DescopeFlow) {
+        flowCoordinator.startFlow(flow)
     }
-
+    
     /**
      * Resume an already running flow after a deep link
      * event. This function should be called to complete `Magic Link`
@@ -231,4 +228,12 @@ class DescopeFlowView : ViewGroup {
         Inline,
         DoNothing,
     }
+    
+    // Deprecated
+
+    @Deprecated("Use startFlow instead", replaceWith = ReplaceWith("startFlow(flow)"))
+    fun run(flow: DescopeFlow) {
+        startFlow(flow)
+    }
+    
 }

--- a/descopesdk/src/main/java/com/descope/internal/http/ClientErrors.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/ClientErrors.kt
@@ -30,7 +30,7 @@ internal fun failureFromResponseCode(code: Int): String? {
         403 -> "The request was forbidden"
         404 -> "The resource was not found"
         500, 503 -> "The request failed with status code $code"
-        in 500..599 -> "The server was unreachable"
+        in 500..599 -> "The server was unreachable ($code)"
         else -> "The server returned status code $code"
     }
 }

--- a/descopesdk/src/main/java/com/descope/sdk/Config.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Config.kt
@@ -83,13 +83,13 @@ open class DescopeLogger(open val level: Level, open val unsafe: Boolean) {
         /**
          * A simple logger that prints basic error and info logs using `println`.
          */
-        val basicLogger: DescopeLogger = ConsoleLogger.basic
+        val basicLogger: DescopeLogger by lazy { ConsoleLogger.basic }
 
         /**
          * A simple logger that prints all logs using `println`, but does not output any
          * potentially unsafe runtime values unless a debugger is attached.
          */
-        val debugLogger: DescopeLogger = ConsoleLogger.debug
+        val debugLogger: DescopeLogger by lazy { ConsoleLogger.debug }
 
         /**
          * A simple logger that prints all logs using `println`, including potentially unsafe
@@ -97,7 +97,7 @@ open class DescopeLogger(open val level: Level, open val unsafe: Boolean) {
          * 
          * - **IMPORTANT**: Do not use unsafeLogger in release builds intended for production.
          */
-        val unsafeLogger: DescopeLogger = ConsoleLogger.unsafe
+        val unsafeLogger: DescopeLogger by lazy { ConsoleLogger.unsafe }
     }
     
     /** The severity of a log message. */


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/11242
https://github.com/descope/etc/issues/11243
https://github.com/descope/etc/issues/11244

## Description

- Change logger initialization to lazy to prevent cycles
- Rename `run` to `startFlow` to keep inline with iOS
- Add a fallback scope in case the lifecycle owner is not found
- Log adjustments
- Allow success to be called on started state for no-screen flows
- Add flow reload mechanism on failure


## Must

-   [x] Tests
-   [x] Documentation (if applicable)
