### PR TITLE
Added Cookie Name support/tests/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ override fun onCreate() {
         if (BuildConfig.DEBUG) {
             logger = DescopeLogger.debugLogger
         }
+        // override cookie names if your app uses different names (default: "DS" and "DSR")
+        sessionCookieName = "my_session_cookie"
+        refreshCookieName = "my_refresh_cookie"
     }
 }
 ```
+
+> **Note:** If your session cookies [use different names](https://docs.descope.com/flows/actions/end-action#refresh-cookie-name) than the defaults (`DS` for session and `DSR` for refresh), you can override them via `sessionCookieName` and `refreshCookieName` in the setup block.
 
 Authenticate the user in your application by starting one of the
 authentication methods. For example, let's use OTP via email:
@@ -71,7 +76,7 @@ val authResponse = try {
             logError("Unexpected authentication failure: $e")
             showUnexpectedErrorAlert(e)
         }
-    }    
+    }
 }
 // we create a DescopeSession object that represents an authenticated user session
 val session = DescopeSession(authResponse)
@@ -186,13 +191,13 @@ override fun onCreate() {
 }
 ```
 
-When the user wants to sign out of the application we clear it 
+When the user wants to sign out of the application we clear it
 from the session manager and revoke the active session:
 
 ```kotlin
 Descope.sessionManager.clearSession()
 Descope.sessionManager.session?.refreshJwt?.let { refreshJwt ->
-    // revoke can be called without waiting for the response or 
+    // revoke can be called without waiting for the response or
     // any error handling since it's not a required measure
     // to log the user out
     myScope.launch(Dispatchers.Main) {
@@ -212,10 +217,10 @@ for more details.
 
 ## Running Flows
 
-We can authenticate users by building and running Flows. Flows are built in the Descope 
+We can authenticate users by building and running Flows. Flows are built in the Descope
 [flow editor](https://app.descope.com/flows). The editor allows you to easily
 define both the behavior and the UI that take the user through their
-authentication journey. Read more about it in the  Descope
+authentication journey. Read more about it in the Descope
 [getting started](https://docs.descope.com/build/guides/gettingstarted/) guide.
 
 ### Setup #1: Define and host your flow
@@ -241,6 +246,7 @@ Any activity can handle an incoming App Link, however in order to resume the flo
 used to run the flow must be called with the `resumeFromDeepLink()` function.
 
 _this code example demonstrates how app links can be handled - you're app architecture might differ'_
+
 ```kotlin
 class FlowRedirectActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -263,6 +269,7 @@ class FlowRedirectActivity : AppCompatActivity() {
 ```
 
 #### Add a matching Manifest declaration
+
 ```xml
 <activity
     android:name=".FlowRedirectActivity"
@@ -327,7 +334,7 @@ val descopeFlow = DescopeFlow("<URL_FOR_FLOW_IN_SETUP_#1>")
 
 // set the OAuth provider ID that is configured to "sign in with Google"
 descopeFlow.oauthNativeProvider = OAuthProvider.Google
-// set the oauth redirect URI to use your app's deep link 
+// set the oauth redirect URI to use your app's deep link
 descopeFlow.oauthRedirect = "<URL_FOR_APP_LINK_IN_SETUP_#2>"
 // customize the flow presentation further
 descopeFlow.presentation = flowPresentation

--- a/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -16,6 +16,10 @@ import java.net.HttpCookie
 
 internal open class DescopeClient(internal val config: DescopeConfig, systemInfo: SystemInfo) : HttpClient(config.baseUrl ?: baseUrlForProjectId(config.projectId), config.logger, config.networkClient) {
 
+    private val jwtDecoder: (String, List<HttpCookie>) -> JwtServerResponse = { json, cookies ->
+        JwtServerResponse.fromJson(json, cookies, config.sessionCookieName, config.refreshCookieName)
+    }
+
     // OTP
 
     suspend fun otpSignUp(method: DeliveryMethod, loginId: String, details: SignUpDetails?): MaskedAddressServerResponse = post(
@@ -49,7 +53,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun otpVerify(method: DeliveryMethod, loginId: String, code: String): JwtServerResponse = post(
         route = "auth/otp/verify/${method.route()}",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "loginId" to loginId,
             "code" to code,
@@ -102,7 +106,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun totpVerify(loginId: String, code: String, options: List<SignInOptions>?): JwtServerResponse = post(
         route = "auth/totp/verify",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         headers = authorization(options?.refreshJwt),
         body = mapOf(
             "loginId" to loginId,
@@ -133,7 +137,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun passkeySignUpFinish(transactionId: String, response: String): JwtServerResponse = post(
         route = "auth/webauthn/signup/finish",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "transactionId" to transactionId,
             "response" to response,
@@ -153,7 +157,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun passkeySignInFinish(transactionId: String, response: String): JwtServerResponse = post(
         route = "auth/webauthn/signin/finish",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "transactionId" to transactionId,
             "response" to response,
@@ -202,7 +206,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun passwordSignUp(loginId: String, password: String, details: SignUpDetails?): JwtServerResponse = post(
         route = "auth/password/signup",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "loginId" to loginId,
             "password" to password,
@@ -212,7 +216,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun passwordSignIn(loginId: String, password: String): JwtServerResponse = post(
         route = "auth/password/signin",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "loginId" to loginId,
             "password" to password,
@@ -231,7 +235,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun passwordReplace(loginId: String, oldPassword: String, newPassword: String) = post(
         route = "auth/password/replace",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "loginId" to loginId,
             "oldPassword" to oldPassword,
@@ -315,7 +319,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun magicLinkVerify(token: String): JwtServerResponse = post(
         route = "auth/magiclink/verify",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "token" to token,
         ),
@@ -370,7 +374,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun enchantedLinkCheckForSession(pendingRef: String): JwtServerResponse = post(
         route = "auth/enchantedlink/pending-session",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "pendingRef" to pendingRef,
         ),
@@ -391,7 +395,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun oauthWebExchange(code: String): JwtServerResponse = post(
         route = "auth/oauth/exchange",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "code" to code,
         ),
@@ -410,7 +414,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun oauthNativeFinish(provider: OAuthProvider, stateId: String, identityToken: String): JwtServerResponse = post(
         route = "auth/oauth/native/finish",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "provider" to provider.name,
             "stateId" to stateId,
@@ -433,7 +437,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun ssoExchange(code: String): JwtServerResponse = post(
         route = "auth/saml/exchange",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "code" to code,
         ),
@@ -443,7 +447,7 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun flowExchange(authorizationCode: String, codeVerifier: String): JwtServerResponse = post(
         route = "flow/exchange",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf(
             "authorizationCode" to authorizationCode,
             "codeVerifier" to codeVerifier,
@@ -480,13 +484,13 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
 
     suspend fun refresh(refreshJwt: String): JwtServerResponse = post(
         route = "auth/refresh",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         headers = authorization(refreshJwt),
     )
 
     suspend fun exchangeExternalToken(externalToken: String): JwtServerResponse = post(
         route = "auth/refresh",
-        decoder = JwtServerResponse::fromJson,
+        decoder = jwtDecoder,
         body = mapOf("externalToken" to externalToken)
     )
 

--- a/descopesdk/src/main/java/com/descope/internal/http/Responses.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/Responses.kt
@@ -21,15 +21,20 @@ internal data class JwtServerResponse(
     val cookiePath: String,
 ) {
     companion object {
-        fun fromJson(json: String, cookies: List<HttpCookie>) = JSONObject(json).run {
+        fun fromJson(
+            json: String,
+            cookies: List<HttpCookie>,
+            sessionCookieName: String = SESSION_COOKIE_NAME,
+            refreshCookieName: String = REFRESH_COOKIE_NAME,
+        ) = JSONObject(json).run {
             var sessionJwt: String? = null
             var refreshJwt: String? = null
 
             // check cookies for tokens
             cookies.forEach {
                 when (it.name) {
-                    SESSION_COOKIE_NAME -> sessionJwt = it.value
-                    REFRESH_COOKIE_NAME -> refreshJwt = it.value
+                    sessionCookieName -> sessionJwt = it.value
+                    refreshCookieName -> refreshJwt = it.value
                 }
             }
 

--- a/descopesdk/src/main/java/com/descope/sdk/Config.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Config.kt
@@ -11,6 +11,18 @@ import java.net.URL
 class DescopeConfig(val projectId: String) {
     /** An optional override for the base URL of the Descope server. */
     var baseUrl: String? = null
+
+    /**
+     * The name of the session cookie used for authentication.
+     * Defaults to "DS" if not specified. Override this if your cookies are named differently.
+     */
+    var sessionCookieName: String = "DS"
+
+    /**
+     * The name of the refresh cookie used for authentication.
+     * Defaults to "DSR" if not specified. Override this if your cookies are named differently.
+     */
+    var refreshCookieName: String = "DSR"
     
     /**
      * An optional object to handle logging in the Descope SDK.

--- a/descopesdk/src/test/java/com/descope/internal/http/ResponsesTest.kt
+++ b/descopesdk/src/test/java/com/descope/internal/http/ResponsesTest.kt
@@ -1,0 +1,68 @@
+package com.descope.internal.http
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.net.HttpCookie
+
+class ResponsesTest {
+
+    private val sessionJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJodHRwczovL2Rlc2NvcGUuY29tL2JsYS9QMTIzIn0.x"
+    private val refreshJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJodHRwczovL2Rlc2NvcGUuY29tL2JsYS9QMTIzIn0.y"
+
+    @Test
+    fun jwtServerResponse_fromJson_defaultCookieNames() {
+        val json = """{"firstSeen":false,"cookieDomain":"example.com","cookiePath":"/"}"""
+        val cookies = listOf(
+            HttpCookie(SESSION_COOKIE_NAME, sessionJwt),
+            HttpCookie(REFRESH_COOKIE_NAME, refreshJwt),
+        )
+        val response = JwtServerResponse.fromJson(json, cookies)
+        assertEquals(sessionJwt, response.sessionJwt)
+        assertEquals(refreshJwt, response.refreshJwt)
+    }
+
+    @Test
+    fun jwtServerResponse_fromJson_customCookieNames() {
+        val customSessionName = "my_session"
+        val customRefreshName = "my_refresh"
+        val json = """{"firstSeen":false,"cookieDomain":"example.com","cookiePath":"/"}"""
+        val cookies = listOf(
+            HttpCookie(customSessionName, sessionJwt),
+            HttpCookie(customRefreshName, refreshJwt),
+        )
+        val response = JwtServerResponse.fromJson(json, cookies, customSessionName, customRefreshName)
+        assertEquals(sessionJwt, response.sessionJwt)
+        assertEquals(refreshJwt, response.refreshJwt)
+    }
+
+    @Test
+    fun jwtServerResponse_fromJson_customCookieNames_ignoresDefaultNames() {
+        val customSessionName = "my_session"
+        val customRefreshName = "my_refresh"
+        val json = """{"firstSeen":false,"cookieDomain":"example.com","cookiePath":"/"}"""
+        val cookies = listOf(
+            HttpCookie(SESSION_COOKIE_NAME, "wrong-session"),
+            HttpCookie(REFRESH_COOKIE_NAME, "wrong-refresh"),
+            HttpCookie(customSessionName, sessionJwt),
+            HttpCookie(customRefreshName, refreshJwt),
+        )
+        val response = JwtServerResponse.fromJson(json, cookies, customSessionName, customRefreshName)
+        assertEquals(sessionJwt, response.sessionJwt)
+        assertEquals(refreshJwt, response.refreshJwt)
+    }
+
+    @Test
+    fun jwtServerResponse_fromJson_defaultNames_notFoundWithCustomNames() {
+        val customSessionName = "my_session"
+        val customRefreshName = "my_refresh"
+        val json = """{"firstSeen":false,"cookieDomain":"example.com","cookiePath":"/"}"""
+        val cookies = listOf(
+            HttpCookie(customSessionName, sessionJwt),
+            HttpCookie(customRefreshName, refreshJwt),
+        )
+        val response = JwtServerResponse.fromJson(json, cookies)
+        assertNull(response.sessionJwt)
+        assertNull(response.refreshJwt)
+    }
+}

--- a/descopesdk/src/test/java/com/descope/session/TokenTest.kt
+++ b/descopesdk/src/test/java/com/descope/session/TokenTest.kt
@@ -102,6 +102,20 @@ class TokenTest {
     }
 
     @Test
+    fun cookies_customCookieNames() {
+        val customSessionName = "my_session_cookie"
+        val customRefreshName = "my_refresh_cookie"
+        val cookies = mutableListOf<HttpCookie>()
+        cookies.add(HttpCookie(customSessionName, jwtForP123))
+        cookies.add(HttpCookie(customRefreshName, laterJwtForP123))
+        assertEquals(jwtForP123, findJwtInCookies(name = customSessionName, cookies.joinToString(separator = "; ")))
+        assertEquals(laterJwtForP123, findJwtInCookies(name = customRefreshName, cookies.joinToString(separator = "; ")))
+        // Default cookie names should not find anything
+        assertEquals(null, findJwtInCookies(name = SESSION_COOKIE_NAME, cookies.joinToString(separator = "; ")))
+        assertEquals(null, findJwtInCookies(name = REFRESH_COOKIE_NAME, cookies.joinToString(separator = "; ")))
+    }
+
+    @Test
     fun cookies_multipleDs_multipleStrings() {
         val cookies = mutableListOf<HttpCookie>()
         cookies.add(HttpCookie(SESSION_COOKIE_NAME, laterJwtForP123))


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/14211

## Description

Added the ability to override the `DS` and `DSR` cookie names with custom ones, if used with the End Action in a Descope Flow.

## Must

-   [X] Tests
-   [X] Documentation (if applicable)
