### PR TITLE
feat: support external authentication in flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ written for Android. You can read more on the [Descope Website](https://descope.
 Add the following to your `build.gradle` dependencies:
 
 ```groovy
-implementation 'com.descope:descope-kotlin:0.18.2'
+implementation 'com.descope:descope-kotlin:0.19.0'
 ```
 
 ## Quickstart

--- a/descopesdk/src/main/java/com/descope/Descope.kt
+++ b/descopesdk/src/main/java/com/descope/Descope.kt
@@ -119,13 +119,13 @@ object Descope {
     /**
      * Resumes an ongoing authentication that's waiting for an external authentication step.
      *
-     * When a flow performs authentication via `Magic Link`, OAuth, SSO, or external
+     * When a flow performs authentication via Magic Link, OAuth, SSO, or external
      * authentication at some point it will wait for the user to be redirected back to
      * the app via a deep link. The host application is expected to intercept the deep
      * link via App Links (or a custom scheme) and resume the running flow with it.
      *
      * You can do this by calling this function and passing the URI from the incoming
-     * intent. For example, from your `Activity.onNewIntent`:
+     * intent. For example, from your Activity.onNewIntent:
      *
      *     override fun onNewIntent(intent: Intent) {
      *         super.onNewIntent(intent)

--- a/descopesdk/src/main/java/com/descope/Descope.kt
+++ b/descopesdk/src/main/java/com/descope/Descope.kt
@@ -3,6 +3,7 @@
 package com.descope
 
 import android.content.Context
+import android.net.Uri
 import com.descope.sdk.DescopeAuth
 import com.descope.sdk.DescopeConfig
 import com.descope.sdk.DescopeEnchantedLink
@@ -114,7 +115,32 @@ object Descope {
     /** Authentication with passwords. */
     val password: DescopePassword
         get() = sdk.password
-    
+
+    /**
+     * Resumes an ongoing authentication that's waiting for an external authentication step.
+     *
+     * When a flow performs authentication via `Magic Link`, OAuth, SSO, or external
+     * authentication at some point it will wait for the user to be redirected back to
+     * the app via a deep link. The host application is expected to intercept the deep
+     * link via App Links (or a custom scheme) and resume the running flow with it.
+     *
+     * You can do this by calling this function and passing the URI from the incoming
+     * intent. For example, from your `Activity.onNewIntent`:
+     *
+     *     override fun onNewIntent(intent: Intent) {
+     *         super.onNewIntent(intent)
+     *         intent.data?.let { Descope.handleUri(it) }
+     *     }
+     *
+     * - **Important**: This function must be called on the main thread, or it will throw
+     * a [com.descope.types.DescopeException.flowSetup] error.
+     *
+     * @param uri The URI to use for resuming the authentication.
+     * @return `true` when an ongoing authentication handled the URI or `false` to
+     *   let the caller know that the function didn't handle it.
+     */
+    fun handleUri(uri: Uri): Boolean = sdk.handleUri(uri)
+
     // The underlying `DescopeSdk` object used by the `Descope` singleton.
     internal lateinit var sdk: DescopeSdk
     

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
@@ -80,7 +80,7 @@ class DescopeFlow {
     var oauthNativeProvider: OAuthProvider? = null
 
     /**
-     * An optional deep link link URL to use when performing OAuth authentication, overriding
+     * An optional deep link URL to use when performing OAuth authentication, overriding
      * whatever is configured in the flow or project.
      * - **IMPORTANT NOTE**: even though App Links are the recommended way to configure
      * deep links, some browsers, such as Opera, do not respect them and open the URLs inline.
@@ -99,7 +99,7 @@ class DescopeFlow {
     var oauthRedirectCustomScheme: String? = null
 
     /**
-     * An optional deep link link URL to use performing SSO authentication, overriding
+     * An optional deep link URL to use performing SSO authentication, overriding
      * whatever is configured in the flow or project
      * - **IMPORTANT NOTE**: even though App Links are the recommended way to configure
      * deep links, some browsers, such as Opera, do not respect them and open the URLs inline.
@@ -118,7 +118,26 @@ class DescopeFlow {
     var ssoRedirectCustomScheme: String? = null
 
     /**
-     * An optional deep link link URL to use when sending magic link emails, overriding
+     * An optional deep link URL to use when performing external authentication, overriding
+     * whatever is configured in the flow or project.
+     * - **IMPORTANT NOTE**: even though App Links are the recommended way to configure
+     * deep links, some browsers, such as Opera, do not respect them and open the URLs inline.
+     * It is possible to circumvent this issue by providing a custom scheme via [externalAuthRedirectCustomScheme]
+     */
+    var externalAuthRedirect: String? = null
+
+    /**
+     * An optional custom scheme based URL, e.g. `mycustomscheme://myhost`,
+     * to use when performing external authentication overriding whatever is configured in the flow or project.
+     * Functionally, this URL is exactly the same as [externalAuthRedirect], and will be used in its stead, only
+     * when the user has a default browser that does not honor App Links by default.
+     * That means the `https` based App Links are opened inline in the browser, instead
+     * of being handled by the application.
+     */
+    var externalAuthRedirectCustomScheme: String? = null
+
+    /**
+     * An optional deep link URL to use when sending magic link emails, overriding
      * whatever is configured in the flow or project
      */
     var magicLinkRedirect: String? = null

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
@@ -99,7 +99,7 @@ class DescopeFlow {
     var oauthRedirectCustomScheme: String? = null
 
     /**
-     * An optional deep link URL to use performing SSO authentication, overriding
+     * An optional deep link URL to use when performing SSO authentication, overriding
      * whatever is configured in the flow or project
      * - **IMPORTANT NOTE**: even though App Links are the recommended way to configure
      * deep links, some browsers, such as Opera, do not respect them and open the URLs inline.

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -410,18 +410,18 @@ private const val loggingScript = """
 })();
 """
 
-private fun makeSetupScript(systemInfo: SystemInfo) = $$"""
+private fun makeSetupScript(systemInfo: SystemInfo) = """
 
 window.descopeBridge = {
     hostInfo: {
         sdkName: 'android',
-        sdkVersion: $${DescopeSdk.VERSION.javaScriptLiteralString()},
+        sdkVersion: ${DescopeSdk.VERSION.javaScriptLiteralString()},
         platformName: 'android',
-        platformVersion: $${systemInfo.platformVersion.javaScriptLiteralString()},
-        appName: $${systemInfo.appName.javaScriptLiteralString()},
-        appVersion: $${systemInfo.appVersion.javaScriptLiteralString()},
-        device: $${systemInfo.device.javaScriptLiteralString()},
-        webauthn: $$isWebAuthnSupported,
+        platformVersion: ${systemInfo.platformVersion.javaScriptLiteralString()},
+        appName: ${systemInfo.appName.javaScriptLiteralString()},
+        appVersion: ${systemInfo.appVersion.javaScriptLiteralString()},
+        device: ${systemInfo.device.javaScriptLiteralString()},
+        webauthn: $isWebAuthnSupported,
     },
 
     abortFlow(reason) {
@@ -517,7 +517,7 @@ window.descopeBridge = {
             const config = window.customElements?.get('descope-wc')?.sdkConfigOverrides || {}
 
             const headers = config?.baseHeaders || {}
-            console.debug(`Descope ${headers['x-descope-sdk-name'] || 'unknown'} package version "${headers['x-descope-sdk-version'] || 'unknown'}"`)
+            console.debug(`Descope ${"$"}{headers['x-descope-sdk-name'] || 'unknown'} package version "${"$"}{headers['x-descope-sdk-version'] || 'unknown'}"`)
 
             const hostInfo = window.descopeBridge.hostInfo
             headers['x-descope-bridge-name'] = hostInfo.sdkName
@@ -564,7 +564,7 @@ window.descopeBridge = {
         updateRefreshJwt(refreshJwt) {
             if (refreshJwt) {
                 const storagePrefix = this.component.storagePrefix || ''
-                const storageKey = storagePrefix + $${REFRESH_COOKIE_NAME.javaScriptLiteralString()}
+                const storageKey = storagePrefix + ${REFRESH_COOKIE_NAME.javaScriptLiteralString()}
                 window.localStorage.setItem(storageKey, refreshJwt)
             }
         },

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -307,6 +307,7 @@ internal sealed class FlowBridgeRequest {
     class OAuthNative(val start: JSONObject) : FlowBridgeRequest()
     class OAuthWeb(val startUrl: String) : FlowBridgeRequest()
     class Sso(val startUrl: String) : FlowBridgeRequest()
+    class ExternalAuth(val startUrl: String) : FlowBridgeRequest()
     class WebAuthnCreate(val transactionId: String, val options: String) : FlowBridgeRequest()
     class WebAuthnGet(val transactionId: String, val options: String) : FlowBridgeRequest()
 
@@ -315,6 +316,7 @@ internal sealed class FlowBridgeRequest {
             is OAuthNative -> "oauthNative"
             is OAuthWeb -> "oauthWeb"
             is Sso -> "sso"
+            is ExternalAuth -> "externalAuth"
             is WebAuthnCreate -> "webauthnCreate"
             is WebAuthnGet -> "webauthnGet"
         }
@@ -328,6 +330,7 @@ internal sealed class FlowBridgeRequest {
                     "oauthNative" -> OAuthNative(start = getJSONObject("start"))
                     "oauthWeb" -> OAuthWeb(startUrl = getString("startUrl"))
                     "sso" -> Sso(startUrl = getString("startUrl"))
+                    "externalAuth" -> ExternalAuth(startUrl = getString("startUrl"))
                     "webauthnCreate" -> WebAuthnCreate(transactionId = getString("transactionId"), options = getString("options"))
                     "webauthnGet" -> WebAuthnGet(transactionId = getString("transactionId"), options = getString("options"))
                     else -> throw DescopeException.flowFailed.with(message = "Unexpected server response in flow")

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -50,7 +50,6 @@ internal class FlowBridge(val webView: WebView) {
     var listener: Listener? = null
     var logger: DescopeLogger? = null
     var attributes = FlowBridgeAttributes()
-    var pendingDeepLinkType: String? = null
 
     private val handler = Handler(Looper.getMainLooper())
     private var alreadySetUp = false
@@ -117,7 +116,6 @@ internal class FlowBridge(val webView: WebView) {
         handler.post {
             try {
                 val request = FlowBridgeRequest.fromJson(response)
-                if (request is FlowBridgeRequest.WebAuth) pendingDeepLinkType = request.variant
                 listener?.onRequest(request)
             } catch (e: DescopeException) {
                 listener?.onError(e)
@@ -249,7 +247,6 @@ internal class FlowBridge(val webView: WebView) {
         alreadySetUp = false
         startedAt = System.currentTimeMillis()
         attempts = 1
-        pendingDeepLinkType = null
         webView.loadUrl(url)
     }
 
@@ -271,7 +268,6 @@ internal class FlowBridge(val webView: WebView) {
     }
 
     fun postResponse(response: FlowBridgeResponse) {
-        if (response is FlowBridgeResponse.DeepLink) pendingDeepLinkType = null
         call("handleResponse", response.typeName, response.payload)
     }
 

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -50,6 +50,7 @@ internal class FlowBridge(val webView: WebView) {
     var listener: Listener? = null
     var logger: DescopeLogger? = null
     var attributes = FlowBridgeAttributes()
+    var pendingDeepLinkType: String? = null
 
     private val handler = Handler(Looper.getMainLooper())
     private var alreadySetUp = false
@@ -116,6 +117,7 @@ internal class FlowBridge(val webView: WebView) {
         handler.post {
             try {
                 val request = FlowBridgeRequest.fromJson(response)
+                if (request is FlowBridgeRequest.WebAuth) pendingDeepLinkType = request.variant
                 listener?.onRequest(request)
             } catch (e: DescopeException) {
                 listener?.onError(e)
@@ -247,6 +249,7 @@ internal class FlowBridge(val webView: WebView) {
         alreadySetUp = false
         startedAt = System.currentTimeMillis()
         attempts = 1
+        pendingDeepLinkType = null
         webView.loadUrl(url)
     }
 
@@ -268,6 +271,7 @@ internal class FlowBridge(val webView: WebView) {
     }
 
     fun postResponse(response: FlowBridgeResponse) {
+        if (response is FlowBridgeResponse.DeepLink) pendingDeepLinkType = null
         call("handleResponse", response.typeName, response.payload)
     }
 
@@ -337,16 +341,14 @@ internal sealed class FlowBridgeRequest {
 internal sealed class FlowBridgeResponse {
     class OAuthNative(val stateId: String, val identityToken: String) : FlowBridgeResponse()
     class WebAuthn(val type: String, val transactionId: String, val response: String) : FlowBridgeResponse()
-    class WebAuth(val type: String, val url: String) : FlowBridgeResponse()
-    class MagicLink(val url: String) : FlowBridgeResponse()
+    class DeepLink(val type: String, val url: String) : FlowBridgeResponse()
     class Failure(val failure: String) : FlowBridgeResponse()
 
     val typeName: String
         get() = when (this) {
             is OAuthNative -> "oauthNative"
             is WebAuthn -> type
-            is WebAuth -> type
-            is MagicLink -> "magicLink"
+            is DeepLink -> type
             is Failure -> "failure"
         }
 
@@ -362,8 +364,7 @@ internal sealed class FlowBridgeResponse {
                 put("transactionId", transactionId)
                 put("response", response)
             }.toString()
-            is WebAuth -> JSONObject().apply { put("url", url) }.toString()
-            is MagicLink -> JSONObject().apply { put("url", url) }.toString()
+            is DeepLink -> JSONObject().apply { put("url", url) }.toString()
             is Failure -> JSONObject().apply { put("failure", failure) }.toString()
         }
 }

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -305,18 +305,14 @@ internal data class FlowBridgeAttributes(
 
 internal sealed class FlowBridgeRequest {
     class OAuthNative(val start: JSONObject) : FlowBridgeRequest()
-    class OAuthWeb(val startUrl: String) : FlowBridgeRequest()
-    class Sso(val startUrl: String) : FlowBridgeRequest()
-    class ExternalAuth(val startUrl: String) : FlowBridgeRequest()
+    class WebAuth(val variant: String, val startUrl: String) : FlowBridgeRequest()
     class WebAuthnCreate(val transactionId: String, val options: String) : FlowBridgeRequest()
     class WebAuthnGet(val transactionId: String, val options: String) : FlowBridgeRequest()
 
     val type
         get() = when (this) {
             is OAuthNative -> "oauthNative"
-            is OAuthWeb -> "oauthWeb"
-            is Sso -> "sso"
-            is ExternalAuth -> "externalAuth"
+            is WebAuth -> variant
             is WebAuthnCreate -> "webauthnCreate"
             is WebAuthnGet -> "webauthnGet"
         }
@@ -328,9 +324,7 @@ internal sealed class FlowBridgeRequest {
             return json.getJSONObject("payload").run {
                 when (type) {
                     "oauthNative" -> OAuthNative(start = getJSONObject("start"))
-                    "oauthWeb" -> OAuthWeb(startUrl = getString("startUrl"))
-                    "sso" -> Sso(startUrl = getString("startUrl"))
-                    "externalAuth" -> ExternalAuth(startUrl = getString("startUrl"))
+                    "oauthWeb", "sso", "externalAuth" -> WebAuth(variant = type, startUrl = getString("startUrl"))
                     "webauthnCreate" -> WebAuthnCreate(transactionId = getString("transactionId"), options = getString("options"))
                     "webauthnGet" -> WebAuthnGet(transactionId = getString("transactionId"), options = getString("options"))
                     else -> throw DescopeException.flowFailed.with(message = "Unexpected server response in flow")

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -98,23 +98,30 @@ class DescopeFlowCoordinator(val webView: WebView) {
         this.flow = flow
         bridge.flow = flow
         bridge.logger = logger
+        sdk?.resume = resumeClosure
         handleStarted()
         bridge.start()
     }
 
-    internal fun resumeFromDeepLink(deepLink: Uri) {
-        if (flow == null) {
-            logger.error("resumeFromDeepLink cannot be called before startFlow")
-            return
+    private val resumeClosure: (Uri) -> Boolean by lazy {
+        val ref = WeakReference(this)
+        val closure: (Uri) -> Boolean = { uri -> ref.get()?.resumeFromDeepLink(uri) ?: false }
+        closure
+    }
+
+    internal fun resumeFromDeepLink(deepLink: Uri): Boolean {
+        if (state != Started && state != Ready) {
+            logger.debug("Ignoring resume URL", state)
+            return false
         }
         activityHelper.closeCustomTab(webView.context)
-        val type = if (deepLink.queryParameterNames.contains("t")) "magicLink" else "oauthWeb"
-        val response = if (type == "magicLink") {
-            FlowBridgeResponse.MagicLink(url = deepLink.toString())
-        } else {
-            FlowBridgeResponse.WebAuth(type = type, url = deepLink.toString())
+        // magic links don't go through the bridge as a request, so detect them from the URL itself
+        val type = when {
+            deepLink.queryParameterNames.contains("t") -> "magicLink"
+            else -> bridge.pendingDeepLinkType ?: "oauthWeb"
         }
-        sendResponse(response)
+        sendResponse(FlowBridgeResponse.DeepLink(type = type, url = deepLink.toString()))
+        return true
     }
 
     // Bridge Events

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -167,6 +167,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         val oauthProvider = flow.oauthNativeProvider?.name ?: ""
         val oauthRedirect = pickRedirectUrl(flow.oauthRedirect, flow.oauthRedirectCustomScheme, useCustomSchemeFallback)
         val ssoRedirect = pickRedirectUrl(flow.ssoRedirect, flow.ssoRedirectCustomScheme, useCustomSchemeFallback)
+        val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
 
         val nativeOptions = JSONObject().apply {
@@ -175,6 +176,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
             put("oauthProvider", oauthProvider)
             put("oauthRedirect", oauthRedirect)
             put("ssoRedirect", ssoRedirect)
+            put("externalAuthRedirect", externalAuthRedirect)
             put("magicLinkRedirect", magicLinkRedirect)
             put("origin", origin)
         }
@@ -281,6 +283,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
                 is FlowBridgeRequest.OAuthNative -> handleOAuthNative(request)
                 is FlowBridgeRequest.OAuthWeb -> handleOAuthWeb(request)
                 is FlowBridgeRequest.Sso -> handleSso(request)
+                is FlowBridgeRequest.ExternalAuth -> handleExternalAuth(request)
                 is FlowBridgeRequest.WebAuthnCreate -> handleWebAuthnCreate(request)
                 is FlowBridgeRequest.WebAuthnGet -> handleWebAuthnGet(request)
             }
@@ -314,6 +317,16 @@ class DescopeFlowCoordinator(val webView: WebView) {
 
     private fun handleSso(request: FlowBridgeRequest.Sso) {
         logger.info("Launching custom tab for sso")
+        try {
+            launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
+        } catch (e: DescopeException) {
+            logger.error("Failed to launch custom tab", e)
+            sendResponse(FlowBridgeResponse.Failure("CustomTabFailure"))
+        }
+    }
+
+    private fun handleExternalAuth(request: FlowBridgeRequest.ExternalAuth) {
+        logger.info("Launching custom tab for external auth")
         try {
             launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
         } catch (e: DescopeException) {

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -281,9 +281,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         scope.launch(Dispatchers.Main) {
             when (request) {
                 is FlowBridgeRequest.OAuthNative -> handleOAuthNative(request)
-                is FlowBridgeRequest.OAuthWeb -> handleOAuthWeb(request)
-                is FlowBridgeRequest.Sso -> handleSso(request)
-                is FlowBridgeRequest.ExternalAuth -> handleExternalAuth(request)
+                is FlowBridgeRequest.WebAuth -> handleWebAuth(request)
                 is FlowBridgeRequest.WebAuthnCreate -> handleWebAuthnCreate(request)
                 is FlowBridgeRequest.WebAuthnGet -> handleWebAuthnGet(request)
             }
@@ -305,28 +303,8 @@ class DescopeFlowCoordinator(val webView: WebView) {
         }
     }
 
-    private fun handleOAuthWeb(request: FlowBridgeRequest.OAuthWeb) {
-        logger.info("Launching custom tab for web-based oauth")
-        try {
-            launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
-        } catch (e: DescopeException) {
-            logger.error("Failed to launch custom tab", e)
-            sendResponse(FlowBridgeResponse.Failure("CustomTabFailure"))
-        }
-    }
-
-    private fun handleSso(request: FlowBridgeRequest.Sso) {
-        logger.info("Launching custom tab for sso")
-        try {
-            launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
-        } catch (e: DescopeException) {
-            logger.error("Failed to launch custom tab", e)
-            sendResponse(FlowBridgeResponse.Failure("CustomTabFailure"))
-        }
-    }
-
-    private fun handleExternalAuth(request: FlowBridgeRequest.ExternalAuth) {
-        logger.info("Launching custom tab for external auth")
+    private fun handleWebAuth(request: FlowBridgeRequest.WebAuth) {
+        logger.info("Launching custom tab for ${request.variant}")
         try {
             launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
         } catch (e: DescopeException) {

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -62,6 +62,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
 
     private val bridge = FlowBridge(webView)
     private var flow: DescopeFlow? = null
+    private var pendingDeepLinkType: String? = null
     private val handler: Handler = Handler(Looper.getMainLooper())
     private val sdk: DescopeSdk?
         get() = flow?.sdk ?: if (Descope.isInitialized) Descope.sdk else null
@@ -98,15 +99,9 @@ class DescopeFlowCoordinator(val webView: WebView) {
         this.flow = flow
         bridge.flow = flow
         bridge.logger = logger
-        sdk?.resume = resumeClosure
+        sdk?.resume = createResumeClosure(WeakReference(this))
         handleStarted()
         bridge.start()
-    }
-
-    private val resumeClosure: (Uri) -> Boolean by lazy {
-        val ref = WeakReference(this)
-        val closure: (Uri) -> Boolean = { uri -> ref.get()?.resumeFromDeepLink(uri) ?: false }
-        closure
     }
 
     internal fun resumeFromDeepLink(deepLink: Uri): Boolean {
@@ -118,8 +113,9 @@ class DescopeFlowCoordinator(val webView: WebView) {
         // magic links don't go through the bridge as a request, so detect them from the URL itself
         val type = when {
             deepLink.queryParameterNames.contains("t") -> "magicLink"
-            else -> bridge.pendingDeepLinkType ?: "oauthWeb"
+            else -> pendingDeepLinkType ?: "oauthWeb"
         }
+        pendingDeepLinkType = null
         sendResponse(FlowBridgeResponse.DeepLink(type = type, url = deepLink.toString()))
         return true
     }
@@ -311,6 +307,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
     }
 
     private fun handleWebAuth(request: FlowBridgeRequest.WebAuth) {
+        pendingDeepLinkType = request.variant
         logger.info("Launching custom tab for ${request.variant}")
         try {
             launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
@@ -454,4 +451,8 @@ private fun createTimerAction(ref: WeakReference<DescopeFlowCoordinator>): (Time
             coordinator.periodicRefreshJwtUpdate()
         }
     }
+}
+
+private fun createResumeClosure(ref: WeakReference<DescopeFlowCoordinator>): (Uri) -> Boolean {
+    return { uri -> ref.get()?.resumeFromDeepLink(uri) ?: false }
 }

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowView.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowView.kt
@@ -145,13 +145,14 @@ class DescopeFlowView : ViewGroup {
     
     /**
      * Resume an already running flow after a deep link
-     * event. This function should be called to complete `Magic Link`
-     * and web-based `OAuth` authentication.
+     * event. This function should be called to complete `Magic Link`,
+     * web-based `OAuth`, `SSO`, and external authentication.
      *
      * @param deepLink The incoming deep link URI
+     * @return `true` if the running flow consumed the URI, `false` otherwise.
      */
-    fun resumeFromDeepLink(deepLink: Uri) {
-        flowCoordinator.resumeFromDeepLink(deepLink)
+    fun resumeFromDeepLink(deepLink: Uri): Boolean {
+        return flowCoordinator.resumeFromDeepLink(deepLink)
     }
 
     // Internal 

--- a/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
@@ -4,6 +4,7 @@ package com.descope.sdk
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.net.Uri
 import android.os.Looper
 import com.descope.android.DescopeSystemInfo
 import com.descope.internal.http.DescopeClient
@@ -18,9 +19,11 @@ import com.descope.internal.routes.Passkey
 import com.descope.internal.routes.Password
 import com.descope.internal.routes.Sso
 import com.descope.internal.routes.Totp
+import com.descope.internal.others.with
 import com.descope.session.DescopeSessionManager
 import com.descope.session.SessionLifecycle
 import com.descope.session.SessionStorage
+import com.descope.types.DescopeException
 
 class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.() -> Unit) {
     var sessionManager: DescopeSessionManager
@@ -64,7 +67,26 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         sessionManager = initDefaultManager(context, config)
     }
 
+    /**
+     * Resumes an ongoing authentication that's waiting for an external authentication step.
+     *
+     * - **Important**: This function must be called on the main thread, or it will throw
+     * a [DescopeException.flowSetup] error.
+     */
+    fun handleUri(uri: Uri): Boolean {
+        if (Looper.getMainLooper().thread != Thread.currentThread()) {
+            throw DescopeException.flowSetup.with(message = "Descope.handleUri must be called on the main thread")
+        }
+        return resume(uri)
+    }
+
     // Internal
+
+    /**
+     * While the flow is running this is set to a closure with a weak reference to
+     * the [DescopeFlowCoordinator] to provide it with the resume URI.
+     */
+    internal var resume: (Uri) -> Boolean = { false }
 
     private fun initDefaultManager(context: Context, config: DescopeConfig): DescopeSessionManager {
         val storage = SessionStorage(context.applicationContext, config.projectId, config.logger)

--- a/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Sdk.kt
@@ -101,6 +101,6 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         const val NAME = "DescopeAndroid"
 
         /** The Descope SDK version */
-        const val VERSION = "0.18.2"
+        const val VERSION = "0.19.0"
     }
 }


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/15077

## Description
- Add support for the `externalAuth` request type in `FlowBridgeRequest` and handle it by launching a custom tab, mirroring `oauthWeb` and `sso`
- Add `externalAuthRedirect` and `externalAuthRedirectCustomScheme` properties on `DescopeFlow`, mirroring the existing OAuth and SSO redirect properties, and pass the resolved value in the bridge's `nativeOptions`
- Unify `OAuthWeb`/`Sso`/`ExternalAuth` bridge requests into a single `WebAuth(variant, startUrl)`, and the `MagicLink`/`WebAuth` responses into a single `DeepLink(type, url)` so all deep-link-based authentication flows through one path
- Track the in-flight `WebAuth` variant on the bridge so `resumeFromDeepLink` sends the correct response type back to the web component, instead of always defaulting to `oauthWeb`
- Add `Descope.handleUri(uri)` and `DescopeSdk.handleUri(uri)` that resume an ongoing authentication when a deep link returns to the app, mirroring iOS's `Descope.handleURL(url)` for cross-SDK parity
- Revert string format change in `DescopeFlowBridge` to support older versions of Kotlin

## Must
- [x] Tests
- [ ] Documentation (if applicable)