### PR TITLE
feat: Log and return CF-Ray response header in API failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ written for Android. You can read more on the [Descope Website](https://descope.
 Add the following to your `build.gradle` dependencies:
 
 ```groovy
-implementation 'com.descope:descope-kotlin:0.19.0'
+implementation 'com.descope:descope-kotlin:0.19.1'
 ```
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ written for Android. You can read more on the [Descope Website](https://descope.
 Add the following to your `build.gradle` dependencies:
 
 ```groovy
-implementation 'com.descope:descope-kotlin:0.19.1'
+implementation 'com.descope:descope-kotlin:0.19.2' // x-release-please-version
 ```
 
 ## Quickstart

--- a/descopesdk/src/main/java/com/descope/internal/http/HttpClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/HttpClient.kt
@@ -74,19 +74,21 @@ internal open class HttpClient(
         val result = try {
             val response = networkClient.sendRequest(url, method, body, combinedHeaders)
             if (response.code != HttpsURLConnection.HTTP_OK) {
-                exceptionFromResponse(response.body)?.let { e ->
+                val cfRay = response.headers.entries.find { it.key.equals("cf-ray", ignoreCase = true) }?.value?.firstOrNull()
+                val trace = if (cfRay != null) " [CF-Ray: $cfRay]" else ""
+                exceptionFromResponse(response.body)?.with(traceId = cfRay)?.let { e ->
                     if (logger.isUnsafeEnabled) {
-                        logger.error("Network call failed with server error", url, e)
+                        logger.error("Network call failed with server error$trace", url, e)
                     } else {
-                        logger.error("Network call to $route failed with ${e.code} server error")
+                        logger.error("Network call to $route failed with ${e.code} server error$trace")
                     }
                     throw e
                 }
-                exceptionFromResponseCode(response.code)?.let { e ->
+                exceptionFromResponseCode(response.code)?.with(traceId = cfRay)?.let { e ->
                     if (logger.isUnsafeEnabled) {
-                        logger.error("Network call failed with ${response.code} http error", url, e)
+                        logger.error("Network call failed with ${response.code} http error$trace", url, e)
                     } else {
-                        logger.error("Network call to $route failed with ${response.code} http error")
+                        logger.error("Network call to $route failed with ${response.code} http error$trace")
                     }
                     throw e
                 }
@@ -140,6 +142,9 @@ private val Map<String, List<String>>.cookies: List<HttpCookie>
         }
         return cookies.toList()
     }
+
+private fun DescopeException.with(traceId: String?): DescopeException =
+    if (traceId == null) this else DescopeException(code = code, desc = desc, message = message, cause = cause, traceId = traceId)
 
 private fun defaultNetworkClient(logger: DescopeLogger?) = object : DescopeNetworkClient {
     override suspend fun sendRequest(url: URL, method: String, body: Map<String, Any?>?, headers: Map<String, String>): DescopeNetworkClient.Response {

--- a/descopesdk/src/main/java/com/descope/internal/http/HttpClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/HttpClient.kt
@@ -168,7 +168,7 @@ private fun defaultNetworkClient(logger: DescopeLogger?) = object : DescopeNetwo
 
             // Return response
             val responseCode = connection.responseCode
-            val responseBody = if (responseCode == HttpsURLConnection.HTTP_OK) {
+            val responseBody = if (responseCode in 200..299) {
                 connection.inputStream.bufferedReader().use { it.readText() }
             } else {
                 connection.errorStream.bufferedReader().use { it.readText() }

--- a/descopesdk/src/main/java/com/descope/internal/http/HttpClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/HttpClient.kt
@@ -73,7 +73,7 @@ internal open class HttpClient(
 
         val result = try {
             val response = networkClient.sendRequest(url, method, body, combinedHeaders)
-            if (response.code != HttpsURLConnection.HTTP_OK) {
+            if (response.code !in 200..299) {
                 val cfRay = response.headers.entries.find { it.key.equals("cf-ray", ignoreCase = true) }?.value?.firstOrNull()
                 val trace = if (cfRay != null) " [CF-Ray: $cfRay]" else ""
                 exceptionFromResponse(response.body)?.with(traceId = cfRay)?.let { e ->
@@ -142,9 +142,6 @@ private val Map<String, List<String>>.cookies: List<HttpCookie>
         }
         return cookies.toList()
     }
-
-private fun DescopeException.with(traceId: String?): DescopeException =
-    if (traceId == null) this else DescopeException(code = code, desc = desc, message = message, cause = cause, traceId = traceId)
 
 private fun defaultNetworkClient(logger: DescopeLogger?) = object : DescopeNetworkClient {
     override suspend fun sendRequest(url: URL, method: String, body: Map<String, Any?>?, headers: Map<String, String>): DescopeNetworkClient.Response {

--- a/descopesdk/src/main/java/com/descope/internal/others/Errors.kt
+++ b/descopesdk/src/main/java/com/descope/internal/others/Errors.kt
@@ -8,6 +8,7 @@ internal fun DescopeException.with(desc: String? = null, message: String? = null
     desc = desc ?: this.desc,
     message = message ?: this.message,
     cause = cause ?: this.cause,
+    traceId = traceId,
 )
 
 internal fun parseServerError(response: String): DescopeException? {

--- a/descopesdk/src/main/java/com/descope/internal/others/Errors.kt
+++ b/descopesdk/src/main/java/com/descope/internal/others/Errors.kt
@@ -3,12 +3,12 @@ package com.descope.internal.others
 import com.descope.types.DescopeException
 import org.json.JSONObject
 
-internal fun DescopeException.with(desc: String? = null, message: String? = null, cause: Throwable? = null) = DescopeException(
+internal fun DescopeException.with(desc: String? = null, message: String? = null, cause: Throwable? = null, traceId: String? = null) = DescopeException(
     code = code,
     desc = desc ?: this.desc,
     message = message ?: this.message,
     cause = cause ?: this.cause,
-    traceId = traceId,
+    traceId = traceId ?: this.traceId,
 )
 
 internal fun parseServerError(response: String): DescopeException? {

--- a/descopesdk/src/main/java/com/descope/types/Error.kt
+++ b/descopesdk/src/main/java/com/descope/types/Error.kt
@@ -49,12 +49,18 @@ private const val API_DESC = "Descope API error"
  * @property cause An optional underlying [Throwable] that caused this error.
  * For example, when a [DescopeException.networkError] is caught the [cause] property
  * will usually have the [Exception] object thrown by the internal `HttpsURLConnection` call.
+ * @property traceId An optional trace identifier for a failed network request.
+ * When the Descope server is accessed through its CDN (the default), this holds the value
+ * of the `CF-Ray` response header of the failed request. You can log this value or send it
+ * to Descope support to help trace and diagnose server errors. It is `null` for errors not
+ * associated with a server response, such as [DescopeException.networkError].
  */
 class DescopeException(
     val code: String,
     val desc: String,
     override val message: String? = null,
     override val cause: Throwable? = null,
+    val traceId: String? = null,
 ) : Exception(), Comparable<DescopeException> {
     
     override fun compareTo(other: DescopeException): Int {
@@ -79,6 +85,9 @@ class DescopeException(
         }
         cause?.run {
             str += ", cause: {$this}"
+        }
+        traceId?.run {
+            str += """, traceId: "$this""""
         }
         str += ")"
         return str

--- a/descopesdk/src/test/java/com/descope/internal/http/DescopeClientTest.kt
+++ b/descopesdk/src/test/java/com/descope/internal/http/DescopeClientTest.kt
@@ -1,7 +1,13 @@
 package com.descope.internal.http
 
+import com.descope.android.SystemInfo
+import com.descope.sdk.DescopeConfig
+import com.descope.sdk.DescopeNetworkClient
+import com.descope.types.DescopeException
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Test
+import java.net.URL
 
 class DescopeClientTest {
 
@@ -13,5 +19,73 @@ class DescopeClientTest {
         assertEquals("https://api.use1.descope.com", baseUrlForProjectId("Puse12aAc4T2V93bddihGEx2Ryhc8e5Z"))
         assertEquals("https://api.use1.descope.com", baseUrlForProjectId("Puse12aAc4T2V93bddihGEx2Ryhc8e5Zfoobar"))
     }
-    
+
+    @Test
+    fun serverError_carriesTraceIdFromCfRayHeader() = runTest {
+        val client = mockClient(
+            code = 400,
+            responseBody = """{"errorCode":"E061102","errorDescription":"server description"}""",
+            responseHeaders = mapOf("CF-Ray" to listOf("8c8e3f5a1b2c3d4e-TLV")),
+        )
+        try {
+            client.post("auth/test", { _, _ -> })
+            fail("Expected a DescopeException to be thrown")
+        } catch (e: DescopeException) {
+            assertEquals("E061102", e.code)
+            assertEquals("8c8e3f5a1b2c3d4e-TLV", e.traceId)
+        }
+    }
+
+    @Test
+    fun httpError_carriesTraceIdFromCfRayHeader() = runTest {
+        val client = mockClient(
+            code = 500,
+            responseBody = "internal error",
+            responseHeaders = mapOf("cf-ray" to listOf("8c8e3f5a1b2c3d4e-TLV")),
+        )
+        try {
+            client.post("auth/test", { _, _ -> })
+            fail("Expected a DescopeException to be thrown")
+        } catch (e: DescopeException) {
+            assertEquals(DescopeException.httpError, e)
+            assertEquals("8c8e3f5a1b2c3d4e-TLV", e.traceId)
+        }
+    }
+
+    @Test
+    fun error_withoutCfRayHeader_hasNullTraceId() = runTest {
+        val client = mockClient(
+            code = 400,
+            responseBody = """{"errorCode":"E061102","errorDescription":"server description"}""",
+        )
+        try {
+            client.post("auth/test", { _, _ -> })
+            fail("Expected a DescopeException to be thrown")
+        } catch (e: DescopeException) {
+            assertEquals("E061102", e.code)
+            assertNull(e.traceId)
+        }
+    }
+
+    @Test
+    fun successfulResponse_isDecoded() = runTest {
+        val client = mockClient(code = 200, responseBody = "response body")
+        assertEquals("response body", client.post("auth/test", { body, _ -> body }))
+    }
+
+    private fun mockClient(code: Int, responseBody: String, responseHeaders: Map<String, List<String>> = emptyMap()): DescopeClient {
+        val config = DescopeConfig("p1").apply {
+            networkClient = object : DescopeNetworkClient {
+                override suspend fun sendRequest(url: URL, method: String, body: Map<String, Any?>?, headers: Map<String, String>) =
+                    DescopeNetworkClient.Response(code = code, body = responseBody, headers = responseHeaders)
+            }
+        }
+        return DescopeClient(config, object : SystemInfo {
+            override val appName = "appName"
+            override val appVersion = "appVersion"
+            override val platformVersion = "platformVersion"
+            override val device = "device"
+        })
+    }
+
 }

--- a/descopesdk/src/test/java/com/descope/types/DescopeExceptionTest.kt
+++ b/descopesdk/src/test/java/com/descope/types/DescopeExceptionTest.kt
@@ -1,9 +1,11 @@
 package com.descope.types
 
 import com.descope.internal.others.parseServerError
+import com.descope.internal.others.with
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 
@@ -35,6 +37,27 @@ class DescopeExceptionTest {
         assertEquals("E102122", exception?.code)
         assertEquals("Flow aborted", exception?.desc)
         assertEquals("User canceled", exception?.message)
+    }
+
+    @Test
+    fun trace_id_preserved() {
+        val exception = DescopeException(code = "E061102", desc = "server description", traceId = "8c8e3f5a1b2c3d4e-TLV")
+        assertEquals("8c8e3f5a1b2c3d4e-TLV", exception.traceId)
+        assertTrue(exception.toString().contains("""traceId: "8c8e3f5a1b2c3d4e-TLV""""))
+        val modified = exception.with(message = "some reason")
+        assertEquals("some reason", modified.message)
+        assertEquals("8c8e3f5a1b2c3d4e-TLV", modified.traceId)
+    }
+
+    @Test
+    fun trace_id_null_by_default() {
+        val payload = JSONObject().apply {
+            put("errorCode", "E061102")
+            put("errorDescription", "server description")
+        }.toString()
+        val exception = parseServerError(payload)
+        assertNull(exception?.traceId)
+        assertEquals(false, exception.toString().contains("traceId"))
     }
 
     @Test

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "extra-files": [
-        "descopesdk/src/main/java/com/descope/sdk/Sdk.kt"
+        "descopesdk/src/main/java/com/descope/sdk/Sdk.kt",
+        "README.md"
       ]
     }
   }


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/15547

## Description
- Log and return CF-Ray response header in API failures

## Must
- [X] Tests
- [X] Documentation (if applicable)