### PR TITLE
feat: expose externalToken on AuthenticationResponse

### DIFF
--- a/descopesdk/src/main/java/com/descope/internal/http/Responses.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/Responses.kt
@@ -21,6 +21,7 @@ internal data class JwtServerResponse(
     val cookiePath: String,
     val cookieName: String?,
     val sessionCookieName: String?,
+    val externalToken: String?,
 ) {
     companion object {
         fun fromJson(json: String, cookies: List<HttpCookie>) = JSONObject(json).run {
@@ -49,6 +50,7 @@ internal data class JwtServerResponse(
                 cookiePath = stringOrEmptyAsNull("cookiePath") ?: "",
                 cookieName = cookieName,
                 sessionCookieName = sessionCookieName,
+                externalToken = stringOrEmptyAsNull("externalToken"),
             )
         }
     }

--- a/descopesdk/src/main/java/com/descope/internal/routes/Shared.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/Shared.kt
@@ -61,6 +61,7 @@ internal fun JwtServerResponse.convert(): AuthenticationResponse {
         sessionToken = Token(sessionJwt),
         user = user.convert(),
         isFirstAuthentication = firstSeen,
+        externalToken = externalToken,
     )
 }
 

--- a/descopesdk/src/main/java/com/descope/types/Responses.kt
+++ b/descopesdk/src/main/java/com/descope/types/Responses.kt
@@ -9,12 +9,14 @@ import com.descope.session.DescopeToken
  * @property refreshToken the refresh token is used to refresh expired session tokens.
  * @property isFirstAuthentication whether this the user's first authentication.
  * @property user information about the user.
+ * @property externalToken a token provided by an external token connector, when configured in the project.
  */
 data class AuthenticationResponse(
     val sessionToken: DescopeToken,
     val refreshToken: DescopeToken,
     val isFirstAuthentication: Boolean,
     val user: DescopeUser,
+    val externalToken: String? = null,
 )
 
 /**

--- a/descopesdk/src/test/java/com/descope/internal/http/JwtServerResponseTest.kt
+++ b/descopesdk/src/test/java/com/descope/internal/http/JwtServerResponseTest.kt
@@ -1,0 +1,34 @@
+package com.descope.internal.http
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class JwtServerResponseTest {
+
+    @Test
+    fun externalToken_populatedWhenPresent() {
+        val json = """
+            {
+                "sessionJwt": "session",
+                "refreshJwt": "refresh",
+                "firstSeen": true,
+                "externalToken": "ext-token-value"
+            }
+        """.trimIndent()
+        val response = JwtServerResponse.fromJson(json, emptyList())
+        assertEquals("ext-token-value", response.externalToken)
+    }
+
+    @Test
+    fun externalToken_nullWhenAbsent() {
+        val json = """
+            {
+                "sessionJwt": "session",
+                "refreshJwt": "refresh",
+                "firstSeen": true
+            }
+        """.trimIndent()
+        val response = JwtServerResponse.fromJson(json, emptyList())
+        assertNull(response.externalToken)
+    }
+}

--- a/descopesdk/src/test/java/com/descope/internal/routes/TestUtils.kt
+++ b/descopesdk/src/test/java/com/descope/internal/routes/TestUtils.kt
@@ -111,6 +111,7 @@ internal val mockJwtResponse = JwtServerResponse(
     cookiePath = "/path",
     cookieName = null,
     sessionCookieName = null,
+    externalToken = null,
 )
 
 private object MockInfo: SystemInfo {


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16830

## Description
- Populate `AuthenticationResponse.externalToken: String?` from the server auth response
- Parsed on `JwtServerResponse` and passed through `convert()`, matching the Flutter and web SDKs

## Must
- [x] Tests
- [ ] Documentation