### PR TITLE
fix: fall back to generic browser check when url resolution fails

### DIFF
--- a/descopesdk/src/main/java/com/descope/internal/others/ActivityHelper.kt
+++ b/descopesdk/src/main/java/com/descope/internal/others/ActivityHelper.kt
@@ -58,6 +58,14 @@ internal val activityHelper = object : ActivityHelper {
     private fun isBrowserSupported(context: Context, uri: Uri): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, uri)
         val component = intent.resolveActivity(context.packageManager)
-        return component != null
+        return when {
+            component != null -> true
+            uri.scheme?.equals("http", ignoreCase = true) == true || uri.scheme?.equals("https", ignoreCase = true) == true -> {
+                val browserIntent = Intent(Intent.ACTION_VIEW, Uri.fromParts("https", "", null))
+                    .addCategory(Intent.CATEGORY_BROWSABLE)
+                context.packageManager.queryIntentActivities(browserIntent, 0).isNotEmpty()
+            }
+            else -> false
+        }
     }
 }


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/17458

## Description
- Fix false `No browser application was found` failure in `ActivityHelper.isBrowserSupported` when the url's host has a verified app link (e.g. `facebook.com`) — `Intent.resolveActivity` returns that app, which is then filtered out by package visibility, yielding `null`

## Must
- [x] Tests
- [ ] Documentation