### PR TITLE
feat(flows): pass the session JWT to the flow bridge

### DIFF
--- a/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
@@ -73,16 +73,6 @@ class DescopeFlow {
     var sessionProvider: (() -> DescopeSession?)? = null
 
     /**
-     * Whether to send the current session JWT on flow start/next requests, exposing
-     * its validated claims to the flow via the `sessionJwtClaims` context key
-     * (e.g. checking the `su` step-up claim). Off by default.
-     *
-     * The session is taken from the [sessionProvider] or the SDK's session manager,
-     * same as for authenticated flows.
-     */
-    var sendSessionToken: Boolean = false
-
-    /**
      * The ID of the oauth provider that is configured to natively "Sign In with Google".
      * Will likely be "google" if the Descope "Google" provider was customized,
      * or alternatively a custom provider ID.

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlow.kt
@@ -73,6 +73,16 @@ class DescopeFlow {
     var sessionProvider: (() -> DescopeSession?)? = null
 
     /**
+     * Whether to send the current session JWT on flow start/next requests, exposing
+     * its validated claims to the flow via the `sessionJwtClaims` context key
+     * (e.g. checking the `su` step-up claim). Off by default.
+     *
+     * The session is taken from the [sessionProvider] or the SDK's session manager,
+     * same as for authenticated flows.
+     */
+    var sendSessionToken: Boolean = false
+
+    /**
      * The ID of the oauth provider that is configured to natively "Sign In with Google".
      * Will likely be "google" if the Descope "Google" provider was customized,
      * or alternatively a custom provider ID.

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -14,6 +14,7 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.descope.internal.http.REFRESH_COOKIE_NAME
+import com.descope.internal.http.SESSION_COOKIE_NAME
 import com.descope.internal.http.failureFromResponseCode
 import com.descope.internal.others.debug
 import com.descope.internal.others.error
@@ -267,8 +268,8 @@ internal class FlowBridge(val webView: WebView) {
 
     // Bridge API
 
-    fun initialize(nativeOptions: String, refreshJwt: String, clientInputs: String) {
-        call("initialize", nativeOptions, refreshJwt, clientInputs)
+    fun initialize(nativeOptions: String, refreshJwt: String, sessionJwt: String, clientInputs: String) {
+        call("initialize", nativeOptions, refreshJwt, sessionJwt, clientInputs)
     }
 
     fun updateRefreshJwt(refreshJwt: String) {
@@ -469,12 +470,13 @@ window.descopeBridge = {
             return true
         },
 
-        initialize(nativeOptions, refreshJwt, clientInputs) {
+        initialize(nativeOptions, refreshJwt, sessionJwt, clientInputs) {
             // update webpage sdk headers and print sdk type and version to native log
             this.updateConfigHeaders()
 
             this.component.nativeOptions = JSON.parse(nativeOptions)
             this.updateRefreshJwt(refreshJwt)
+            this.updateSessionJwt(sessionJwt)
             this.updateClientInputs(clientInputs)
 
             if (this.component.flowStatus === 'error') {
@@ -568,6 +570,16 @@ window.descopeBridge = {
                 const storagePrefix = this.component.storagePrefix || ''
                 const storageKey = storagePrefix + ${REFRESH_COOKIE_NAME.javaScriptLiteralString()}
                 window.localStorage.setItem(storageKey, refreshJwt)
+            }
+        },
+
+        updateSessionJwt(sessionJwt) {
+            // the session JWT is only made available to web components that opted in
+            // via the send-session-token attribute
+            if (sessionJwt && this.component.getAttribute('send-session-token') === 'true') {
+                const storagePrefix = this.component.storagePrefix || ''
+                const storageKey = storagePrefix + ${SESSION_COOKIE_NAME.javaScriptLiteralString()}
+                window.localStorage.setItem(storageKey, sessionJwt)
             }
         },
 

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -578,9 +578,6 @@ window.descopeBridge = {
         },
 
         updateSessionJwt(sessionJwt) {
-            // the session JWT is only made available to web components that opted in
-            // via the send-session-token attribute; cleared otherwise so a value from
-            // a previous session never lingers in the page's persistent storage
             const storagePrefix = this.component.storagePrefix || ''
             const storageKey = storagePrefix + ${SESSION_COOKIE_NAME.javaScriptLiteralString()}
             if (sessionJwt && this.component.getAttribute('send-session-token') === 'true') {

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -276,6 +276,10 @@ internal class FlowBridge(val webView: WebView) {
         call("updateRefreshJwt", refreshJwt)
     }
 
+    fun updateSessionJwt(sessionJwt: String) {
+        call("updateSessionJwt", sessionJwt)
+    }
+
     fun postResponse(response: FlowBridgeResponse) {
         call("handleResponse", response.typeName, response.payload)
     }
@@ -575,11 +579,14 @@ window.descopeBridge = {
 
         updateSessionJwt(sessionJwt) {
             // the session JWT is only made available to web components that opted in
-            // via the send-session-token attribute
+            // via the send-session-token attribute; cleared otherwise so a value from
+            // a previous session never lingers in the page's persistent storage
+            const storagePrefix = this.component.storagePrefix || ''
+            const storageKey = storagePrefix + ${SESSION_COOKIE_NAME.javaScriptLiteralString()}
             if (sessionJwt && this.component.getAttribute('send-session-token') === 'true') {
-                const storagePrefix = this.component.storagePrefix || ''
-                const storageKey = storagePrefix + ${SESSION_COOKIE_NAME.javaScriptLiteralString()}
                 window.localStorage.setItem(storageKey, sessionJwt)
+            } else {
+                window.localStorage.removeItem(storageKey)
             }
         },
 

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -74,10 +74,6 @@ class DescopeFlowCoordinator(val webView: WebView) {
     private val currentSession: DescopeSession?
         get() = if (flow?.sessionProvider != null) flow?.sessionProvider?.invoke() else sdk?.sessionManager?.session?.takeIf { !it.refreshToken.isExpired }
 
-    // the session JWT is only forwarded to the page while it's still valid
-    private fun validSessionJwt(session: DescopeSession?): String =
-        if (session != null && !session.sessionToken.isExpired) session.sessionJwt else ""
-
     private val bridgeListener = object : FlowBridge.Listener {
         override fun onLoaded() = handleLoaded()
         override fun onFound() = initialize()
@@ -196,16 +192,12 @@ class DescopeFlowCoordinator(val webView: WebView) {
         // take one session snapshot so refreshJwt and sessionJwt can't come from different sessions
         val session = currentSession
         val refreshJwt = session?.refreshJwt ?: ""
+        val sessionJwt = validSessionJwt(session)
         val oauthProvider = flow.oauthNativeProvider?.name ?: ""
         val oauthRedirect = pickRedirectUrl(flow.oauthRedirect, flow.oauthRedirectCustomScheme, useCustomSchemeFallback)
         val ssoRedirect = pickRedirectUrl(flow.ssoRedirect, flow.ssoRedirectCustomScheme, useCustomSchemeFallback)
         val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
-
-        // injected into the page's local storage like the refresh JWT, but only for
-        // web components that opted in via send-session-token. An expired session
-        // token is skipped so the flow never sees stale claims
-        val sessionJwt = validSessionJwt(session)
 
         val nativeOptions = JSONObject().apply {
             put("platform", "android")
@@ -482,3 +474,7 @@ private fun createTimerAction(ref: WeakReference<DescopeFlowCoordinator>): (Time
 private fun createResumeClosure(ref: WeakReference<DescopeFlowCoordinator>): (Uri) -> Boolean {
     return { uri -> ref.get()?.resumeFromDeepLink(uri) ?: false }
 }
+
+// the session JWT is only forwarded to the page while it's still valid
+private fun validSessionJwt(session: DescopeSession?): String =
+    if (session != null && !session.sessionToken.isExpired) session.sessionJwt else ""

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -198,7 +198,10 @@ class DescopeFlowCoordinator(val webView: WebView) {
         val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
 
-        val sessionJwt = if (flow.sendSessionToken && session != null && !session.sessionToken.isExpired) session.sessionJwt else ""
+        // passed to the web component like the refresh JWT; the web component decides
+        // whether to send it on flow requests (send-session-token). An expired session
+        // token is skipped so the flow never sees stale claims
+        val sessionJwt = if (session != null && !session.sessionToken.isExpired) session.sessionJwt else ""
 
         val nativeOptions = JSONObject().apply {
             put("platform", "android")
@@ -209,7 +212,6 @@ class DescopeFlowCoordinator(val webView: WebView) {
             put("externalAuthRedirect", externalAuthRedirect)
             put("magicLinkRedirect", magicLinkRedirect)
             put("origin", origin)
-            // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it)
             if (sessionJwt.isNotEmpty()) put("sessionJwt", sessionJwt)
         }
 

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -196,6 +196,8 @@ class DescopeFlowCoordinator(val webView: WebView) {
         val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
 
+        val sessionJwt = if (flow.sendSessionToken) currentSession?.sessionJwt ?: "" else ""
+
         val nativeOptions = JSONObject().apply {
             put("platform", "android")
             put("bridgeVersion", 1)
@@ -205,6 +207,8 @@ class DescopeFlowCoordinator(val webView: WebView) {
             put("externalAuthRedirect", externalAuthRedirect)
             put("magicLinkRedirect", magicLinkRedirect)
             put("origin", origin)
+            // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it)
+            if (sessionJwt.isNotEmpty()) put("sessionJwt", sessionJwt)
         }
 
         var clientInputs = ""

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -74,6 +74,10 @@ class DescopeFlowCoordinator(val webView: WebView) {
     private val currentSession: DescopeSession?
         get() = if (flow?.sessionProvider != null) flow?.sessionProvider?.invoke() else sdk?.sessionManager?.session?.takeIf { !it.refreshToken.isExpired }
 
+    // the session JWT is only forwarded to the page while it's still valid
+    private fun validSessionJwt(session: DescopeSession?): String =
+        if (session != null && !session.sessionToken.isExpired) session.sessionJwt else ""
+
     private val bridgeListener = object : FlowBridge.Listener {
         override fun onLoaded() = handleLoaded()
         override fun onFound() = initialize()
@@ -201,7 +205,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         // injected into the page's local storage like the refresh JWT, but only for
         // web components that opted in via send-session-token. An expired session
         // token is skipped so the flow never sees stale claims
-        val sessionJwt = if (session != null && !session.sessionToken.isExpired) session.sessionJwt else ""
+        val sessionJwt = validSessionJwt(session)
 
         val nativeOptions = JSONObject().apply {
             put("platform", "android")
@@ -416,7 +420,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         handler.post {
             val session = currentSession
             bridge.updateRefreshJwt(session?.refreshJwt ?: "")
-            bridge.updateSessionJwt(if (session != null && !session.sessionToken.isExpired) session.sessionJwt else "")
+            bridge.updateSessionJwt(validSessionJwt(session))
         }
     }
 }

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -414,8 +414,9 @@ class DescopeFlowCoordinator(val webView: WebView) {
 
     internal fun periodicRefreshJwtUpdate() {
         handler.post {
-            val refreshJwt = currentSession?.refreshJwt ?: ""
-            bridge.updateRefreshJwt(refreshJwt)
+            val session = currentSession
+            bridge.updateRefreshJwt(session?.refreshJwt ?: "")
+            bridge.updateSessionJwt(if (session != null && !session.sessionToken.isExpired) session.sessionJwt else "")
         }
     }
 }

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -198,8 +198,8 @@ class DescopeFlowCoordinator(val webView: WebView) {
         val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
 
-        // passed to the web component like the refresh JWT; the web component decides
-        // whether to send it on flow requests (send-session-token). An expired session
+        // injected into the page's local storage like the refresh JWT, but only for
+        // web components that opted in via send-session-token. An expired session
         // token is skipped so the flow never sees stale claims
         val sessionJwt = if (session != null && !session.sessionToken.isExpired) session.sessionJwt else ""
 
@@ -212,7 +212,6 @@ class DescopeFlowCoordinator(val webView: WebView) {
             put("externalAuthRedirect", externalAuthRedirect)
             put("magicLinkRedirect", magicLinkRedirect)
             put("origin", origin)
-            if (sessionJwt.isNotEmpty()) put("sessionJwt", sessionJwt)
         }
 
         var clientInputs = ""
@@ -220,7 +219,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
             clientInputs = flow.clientInputs.toJsonObject().toString()
         }
 
-        bridge.initialize(nativeOptions.toString(), refreshJwt, clientInputs)
+        bridge.initialize(nativeOptions.toString(), refreshJwt, sessionJwt, clientInputs)
     }
 
     // Hooks

--- a/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/descopesdk/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -189,14 +189,16 @@ class DescopeFlowCoordinator(val webView: WebView) {
             ""
         }
 
-        val refreshJwt = currentSession?.refreshJwt ?: ""
+        // take one session snapshot so refreshJwt and sessionJwt can't come from different sessions
+        val session = currentSession
+        val refreshJwt = session?.refreshJwt ?: ""
         val oauthProvider = flow.oauthNativeProvider?.name ?: ""
         val oauthRedirect = pickRedirectUrl(flow.oauthRedirect, flow.oauthRedirectCustomScheme, useCustomSchemeFallback)
         val ssoRedirect = pickRedirectUrl(flow.ssoRedirect, flow.ssoRedirectCustomScheme, useCustomSchemeFallback)
         val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
 
-        val sessionJwt = if (flow.sendSessionToken) currentSession?.sessionJwt ?: "" else ""
+        val sessionJwt = if (flow.sendSessionToken && session != null && !session.sessionToken.isExpired) session.sessionJwt else ""
 
         val nativeOptions = JSONObject().apply {
             put("platform", "android")


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17811

## Related PRs
### Related PRs
- https://github.com/descope/descope-swift/pull/155
- https://github.com/descope/descope-react-native/pull/184
- auth-hosting query param: https://github.com/descope/auth-hosting (companion PR)

## In a Nutshell
- The flow bridge injects the current session JWT into the page's local storage, same as the refresh JWT
- Injected only for web components that opted in via the `send-session-token` attribute
- No new API; expired session tokens are skipped, one session snapshot feeds both JWTs

## Description
Web components with `send-session-token` enabled read the session JWT from web storage and send it on flow start/next requests, so a flow can check the validated session claims server side (for example whether the user already completed step-up) via the `sessionJwtClaims` flow context key. The bridge now makes the native session JWT available in the page's local storage the same way it already does for the refresh JWT - but only when the web component carries the opt-in attribute, so the token never enters page storage otherwise.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)