### PR TITLE
feat(enchantedlink): support enchanted link over SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,38 @@ try {
 }
 ```
 
+### Enchanted Link
+
+Send a user an Enchanted Link over email. The email contains three links, and the
+returned `linkId` tells the user which one to press. Use the `pendingRef` to poll
+until they do.
+
+```kotlin
+try {
+    val response = Descope.enchantedLink.signUpOrIn("andy@example.com")
+    val authResponse = Descope.enchantedLink.pollForSession(response.pendingRef)
+} catch (e: DescopeException) {
+    // Handle errors here
+}
+```
+
+The enchanted link can also be delivered by SMS, using `signUpWithPhone`,
+`signInWithPhone` and `signUpOrInWithPhone`. The login ID is a phone number, and these
+return a `PhoneEnchantedLinkResponse` carrying `maskedPhone` instead of `maskedEmail`.
+Only the correct link is sent in the text message, so the user has nothing to choose.
+
+```kotlin
+try {
+    val response = Descope.enchantedLink.signUpOrInWithPhone("+15551234567")
+    val authResponse = Descope.enchantedLink.pollForSession(response.pendingRef)
+} catch (e: DescopeException) {
+    // Handle errors here
+}
+```
+
+`updatePhone` adds a phone number to an existing user, verified by an enchanted link
+sent over SMS, using the `refreshJwt` of their active session.
+
 ### OAuth
 
 Users can authenticate using their social logins, using the OAuth protocol.

--- a/README.md
+++ b/README.md
@@ -411,17 +411,16 @@ until they do.
 
 ```kotlin
 try {
-    val response = Descope.enchantedLink.signUpOrIn("andy@example.com")
+    val response = Descope.enchantedLink.signUpOrIn(DeliveryMethod.Email, "andy@example.com")
     val authResponse = Descope.enchantedLink.pollForSession(response.pendingRef)
 } catch (e: DescopeException) {
     // Handle errors here
 }
 ```
 
-The enchanted link can also be delivered by SMS, by passing a `DeliveryMethod`. The
-login ID is a phone number, and the returned `EnchantedLinkDeliveryResponse` carries
-`maskedPhone` instead of `maskedEmail`. Only the correct link is sent in the text
-message, so the user has nothing to choose.
+The enchanted link can also be delivered by SMS. The login ID is a phone number, and
+the response carries `maskedPhone` instead of `maskedEmail`. Only the correct link is
+sent in the text message, so the user has nothing to choose.
 
 ```kotlin
 try {

--- a/README.md
+++ b/README.md
@@ -418,14 +418,14 @@ try {
 }
 ```
 
-The enchanted link can also be delivered by SMS, using `signUpWithPhone`,
-`signInWithPhone` and `signUpOrInWithPhone`. The login ID is a phone number, and these
-return a `PhoneEnchantedLinkResponse` carrying `maskedPhone` instead of `maskedEmail`.
-Only the correct link is sent in the text message, so the user has nothing to choose.
+The enchanted link can also be delivered by SMS, by passing a `DeliveryMethod`. The
+login ID is a phone number, and the returned `EnchantedLinkDeliveryResponse` carries
+`maskedPhone` instead of `maskedEmail`. Only the correct link is sent in the text
+message, so the user has nothing to choose.
 
 ```kotlin
 try {
-    val response = Descope.enchantedLink.signUpOrInWithPhone("+15551234567")
+    val response = Descope.enchantedLink.signUpOrIn(DeliveryMethod.Sms, "+15551234567")
     val authResponse = Descope.enchantedLink.pollForSession(response.pendingRef)
 } catch (e: DescopeException) {
     // Handle errors here

--- a/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -324,8 +324,8 @@ internal open class DescopeClient(internal val config: DescopeConfig, internal v
 
     // Enchanted Link
 
-    suspend fun enchantedLinkSignUp(loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkServerResponse = post(
-        route = "auth/enchantedlink/signup/email",
+    suspend fun enchantedLinkSignUp(method: DeliveryMethod, loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkServerResponse = post(
+        route = "auth/enchantedlink/signup/${method.route()}",
         decoder = EnchantedLinkServerResponse::fromJson,
         body = mapOf(
             "loginId" to loginId,
@@ -334,8 +334,8 @@ internal open class DescopeClient(internal val config: DescopeConfig, internal v
         ),
     )
 
-    suspend fun enchantedLinkSignIn(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkServerResponse = post(
-        route = "auth/enchantedlink/signin/email",
+    suspend fun enchantedLinkSignIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkServerResponse = post(
+        route = "auth/enchantedlink/signin/${method.route()}",
         decoder = EnchantedLinkServerResponse::fromJson,
         headers = authorization(options?.refreshJwt),
         body = mapOf(
@@ -345,40 +345,8 @@ internal open class DescopeClient(internal val config: DescopeConfig, internal v
         ),
     )
 
-    suspend fun enchantedLinkSignUpOrIn(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkServerResponse = post(
-        route = "auth/enchantedlink/signup-in/email",
-        decoder = EnchantedLinkServerResponse::fromJson,
-        headers = authorization(options?.refreshJwt),
-        body = mapOf(
-            "loginId" to loginId,
-            "redirectUrl" to uri,
-            "loginOptions" to options?.toMap(),
-        ),
-    )
-
-    suspend fun enchantedLinkSignUpWithPhone(loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkServerResponse = post(
-        route = "auth/enchantedlink/signup/sms",
-        decoder = EnchantedLinkServerResponse::fromJson,
-        body = mapOf(
-            "loginId" to loginId,
-            "user" to details?.toMap(),
-            "redirectUrl" to uri,
-        ),
-    )
-
-    suspend fun enchantedLinkSignInWithPhone(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkServerResponse = post(
-        route = "auth/enchantedlink/signin/sms",
-        decoder = EnchantedLinkServerResponse::fromJson,
-        headers = authorization(options?.refreshJwt),
-        body = mapOf(
-            "loginId" to loginId,
-            "redirectUrl" to uri,
-            "loginOptions" to options?.toMap(),
-        ),
-    )
-
-    suspend fun enchantedLinkSignUpOrInWithPhone(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkServerResponse = post(
-        route = "auth/enchantedlink/signup-in/sms",
+    suspend fun enchantedLinkSignUpOrIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkServerResponse = post(
+        route = "auth/enchantedlink/signup-in/${method.route()}",
         decoder = EnchantedLinkServerResponse::fromJson,
         headers = authorization(options?.refreshJwt),
         body = mapOf(

--- a/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -356,6 +356,38 @@ internal open class DescopeClient(internal val config: DescopeConfig, internal v
         ),
     )
 
+    suspend fun enchantedLinkSignUpWithPhone(loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkServerResponse = post(
+        route = "auth/enchantedlink/signup/sms",
+        decoder = EnchantedLinkServerResponse::fromJson,
+        body = mapOf(
+            "loginId" to loginId,
+            "user" to details?.toMap(),
+            "redirectUrl" to uri,
+        ),
+    )
+
+    suspend fun enchantedLinkSignInWithPhone(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkServerResponse = post(
+        route = "auth/enchantedlink/signin/sms",
+        decoder = EnchantedLinkServerResponse::fromJson,
+        headers = authorization(options?.refreshJwt),
+        body = mapOf(
+            "loginId" to loginId,
+            "redirectUrl" to uri,
+            "loginOptions" to options?.toMap(),
+        ),
+    )
+
+    suspend fun enchantedLinkSignUpOrInWithPhone(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkServerResponse = post(
+        route = "auth/enchantedlink/signup-in/sms",
+        decoder = EnchantedLinkServerResponse::fromJson,
+        headers = authorization(options?.refreshJwt),
+        body = mapOf(
+            "loginId" to loginId,
+            "redirectUrl" to uri,
+            "loginOptions" to options?.toMap(),
+        ),
+    )
+
     suspend fun enchantedLinkUpdateEmail(email: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkServerResponse = post(
         route = "auth/enchantedlink/update/email",
         decoder = EnchantedLinkServerResponse::fromJson,
@@ -363,6 +395,19 @@ internal open class DescopeClient(internal val config: DescopeConfig, internal v
         body = mapOf(
             "loginId" to loginId,
             "email" to email,
+            "redirectUrl" to uri,
+            "addToLoginIDs" to options?.addToLoginIds,
+            "onMergeUseExisting" to options?.onMergeUseExisting,
+        ),
+    )
+
+    suspend fun enchantedLinkUpdatePhone(phone: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkServerResponse = post(
+        route = "auth/enchantedlink/update/phone/sms",
+        decoder = EnchantedLinkServerResponse::fromJson,
+        headers = authorization(refreshJwt),
+        body = mapOf(
+            "loginId" to loginId,
+            "phone" to phone,
             "redirectUrl" to uri,
             "addToLoginIDs" to options?.addToLoginIds,
             "onMergeUseExisting" to options?.onMergeUseExisting,

--- a/descopesdk/src/main/java/com/descope/internal/http/Responses.kt
+++ b/descopesdk/src/main/java/com/descope/internal/http/Responses.kt
@@ -174,14 +174,16 @@ internal data class PasswordPolicyServerResponse(
 internal data class EnchantedLinkServerResponse(
     val linkId: String,
     val pendingRef: String,
-    val maskedEmail: String,
+    val maskedEmail: String? = null,
+    val maskedPhone: String? = null,
 ) {
     companion object {
         fun fromJson(json: String, cookies: List<HttpCookie>) = JSONObject(json).run {
             EnchantedLinkServerResponse(
                 linkId = getString("linkId"),
                 pendingRef = getString("pendingRef"),
-                maskedEmail = getString("maskedEmail"),
+                maskedEmail = stringOrEmptyAsNull("maskedEmail"),
+                maskedPhone = stringOrEmptyAsNull("maskedPhone"),
             )
         }
     }

--- a/descopesdk/src/main/java/com/descope/internal/routes/EnchantedLink.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/EnchantedLink.kt
@@ -7,9 +7,10 @@ import com.descope.sdk.DescopeEnchantedLink
 import com.descope.sdk.DescopeLogger.Level.Error
 import com.descope.sdk.DescopeLogger.Level.Info
 import com.descope.types.AuthenticationResponse
+import com.descope.types.DeliveryMethod
 import com.descope.types.DescopeException
+import com.descope.types.EnchantedLinkDeliveryResponse
 import com.descope.types.EnchantedLinkResponse
-import com.descope.types.PhoneEnchantedLinkResponse
 import com.descope.types.SignInOptions
 import com.descope.types.SignUpDetails
 import com.descope.types.UpdateOptions
@@ -20,28 +21,28 @@ private const val DEFAULT_POLL_DURATION: Long = 2 /* mins */ * 60 /* secs */ * 1
 internal class EnchantedLink(override val client: DescopeClient) : Route, DescopeEnchantedLink {
 
     override suspend fun signUp(loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkResponse =
-        client.enchantedLinkSignUp(loginId, details, uri).convert()
+        client.enchantedLinkSignUp(DeliveryMethod.Email, loginId, details, uri).convert()
 
     override suspend fun signIn(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkResponse =
-        client.enchantedLinkSignIn(loginId, uri, options).convert()
+        client.enchantedLinkSignIn(DeliveryMethod.Email, loginId, uri, options).convert()
 
     override suspend fun signUpOrIn(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkResponse =
-        client.enchantedLinkSignUpOrIn(loginId, uri, options).convert()
+        client.enchantedLinkSignUpOrIn(DeliveryMethod.Email, loginId, uri, options).convert()
 
     override suspend fun updateEmail(email: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkResponse =
         client.enchantedLinkUpdateEmail(email, loginId, uri, refreshJwt, options).convert()
 
-    override suspend fun signUpWithPhone(loginId: String, details: SignUpDetails?, uri: String?): PhoneEnchantedLinkResponse =
-        client.enchantedLinkSignUpWithPhone(loginId, details, uri).convertWithPhone()
+    override suspend fun signUp(method: DeliveryMethod, loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkDeliveryResponse =
+        client.enchantedLinkSignUp(method.asEnchantedLinkMethod(), loginId, details, uri).convert(method)
 
-    override suspend fun signInWithPhone(loginId: String, uri: String?, options: List<SignInOptions>?): PhoneEnchantedLinkResponse =
-        client.enchantedLinkSignInWithPhone(loginId, uri, options).convertWithPhone()
+    override suspend fun signIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkDeliveryResponse =
+        client.enchantedLinkSignIn(method.asEnchantedLinkMethod(), loginId, uri, options).convert(method)
 
-    override suspend fun signUpOrInWithPhone(loginId: String, uri: String?, options: List<SignInOptions>?): PhoneEnchantedLinkResponse =
-        client.enchantedLinkSignUpOrInWithPhone(loginId, uri, options).convertWithPhone()
+    override suspend fun signUpOrIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkDeliveryResponse =
+        client.enchantedLinkSignUpOrIn(method.asEnchantedLinkMethod(), loginId, uri, options).convert(method)
 
-    override suspend fun updatePhone(phone: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): PhoneEnchantedLinkResponse =
-        client.enchantedLinkUpdatePhone(phone, loginId, uri, refreshJwt, options).convertWithPhone()
+    override suspend fun updatePhone(phone: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkDeliveryResponse =
+        client.enchantedLinkUpdatePhone(phone, loginId, uri, refreshJwt, options).convert(DeliveryMethod.Sms)
 
     override suspend fun checkForSession(pendingRef: String): AuthenticationResponse =
         client.enchantedLinkCheckForSession(pendingRef).convert()
@@ -79,8 +80,21 @@ private fun EnchantedLinkServerResponse.convert() = EnchantedLinkResponse(
     maskedEmail = maskedEmail ?: throw DescopeException.decodeError.with(message = "masked email not received"),
 )
 
-private fun EnchantedLinkServerResponse.convertWithPhone() = PhoneEnchantedLinkResponse(
-    linkId = linkId,
-    pendingRef = pendingRef,
-    maskedPhone = maskedPhone ?: throw DescopeException.decodeError.with(message = "masked phone not received"),
-)
+private fun EnchantedLinkServerResponse.convert(method: DeliveryMethod) = when (method) {
+    DeliveryMethod.Email -> EnchantedLinkDeliveryResponse(
+        linkId = linkId,
+        pendingRef = pendingRef,
+        maskedEmail = maskedEmail ?: throw DescopeException.decodeError.with(message = "masked email not received"),
+    )
+
+    else -> EnchantedLinkDeliveryResponse(
+        linkId = linkId,
+        pendingRef = pendingRef,
+        maskedPhone = maskedPhone ?: throw DescopeException.decodeError.with(message = "masked phone not received"),
+    )
+}
+
+private fun DeliveryMethod.asEnchantedLinkMethod() = when (this) {
+    DeliveryMethod.Email, DeliveryMethod.Sms -> this
+    DeliveryMethod.Whatsapp -> throw DescopeException.invalidArguments.with(message = "Enchanted link is not delivered over WhatsApp")
+}

--- a/descopesdk/src/main/java/com/descope/internal/routes/EnchantedLink.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/EnchantedLink.kt
@@ -2,12 +2,14 @@ package com.descope.internal.routes
 
 import com.descope.internal.http.DescopeClient
 import com.descope.internal.http.EnchantedLinkServerResponse
+import com.descope.internal.others.with
 import com.descope.sdk.DescopeEnchantedLink
 import com.descope.sdk.DescopeLogger.Level.Error
 import com.descope.sdk.DescopeLogger.Level.Info
 import com.descope.types.AuthenticationResponse
 import com.descope.types.DescopeException
 import com.descope.types.EnchantedLinkResponse
+import com.descope.types.PhoneEnchantedLinkResponse
 import com.descope.types.SignInOptions
 import com.descope.types.SignUpDetails
 import com.descope.types.UpdateOptions
@@ -28,6 +30,18 @@ internal class EnchantedLink(override val client: DescopeClient) : Route, Descop
 
     override suspend fun updateEmail(email: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkResponse =
         client.enchantedLinkUpdateEmail(email, loginId, uri, refreshJwt, options).convert()
+
+    override suspend fun signUpWithPhone(loginId: String, details: SignUpDetails?, uri: String?): PhoneEnchantedLinkResponse =
+        client.enchantedLinkSignUpWithPhone(loginId, details, uri).convertWithPhone()
+
+    override suspend fun signInWithPhone(loginId: String, uri: String?, options: List<SignInOptions>?): PhoneEnchantedLinkResponse =
+        client.enchantedLinkSignInWithPhone(loginId, uri, options).convertWithPhone()
+
+    override suspend fun signUpOrInWithPhone(loginId: String, uri: String?, options: List<SignInOptions>?): PhoneEnchantedLinkResponse =
+        client.enchantedLinkSignUpOrInWithPhone(loginId, uri, options).convertWithPhone()
+
+    override suspend fun updatePhone(phone: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): PhoneEnchantedLinkResponse =
+        client.enchantedLinkUpdatePhone(phone, loginId, uri, refreshJwt, options).convertWithPhone()
 
     override suspend fun checkForSession(pendingRef: String): AuthenticationResponse =
         client.enchantedLinkCheckForSession(pendingRef).convert()
@@ -62,5 +76,11 @@ internal class EnchantedLink(override val client: DescopeClient) : Route, Descop
 private fun EnchantedLinkServerResponse.convert() = EnchantedLinkResponse(
     linkId = linkId,
     pendingRef = pendingRef,
-    maskedEmail = maskedEmail,
+    maskedEmail = maskedEmail ?: throw DescopeException.decodeError.with(message = "masked email not received"),
+)
+
+private fun EnchantedLinkServerResponse.convertWithPhone() = PhoneEnchantedLinkResponse(
+    linkId = linkId,
+    pendingRef = pendingRef,
+    maskedPhone = maskedPhone ?: throw DescopeException.decodeError.with(message = "masked phone not received"),
 )

--- a/descopesdk/src/main/java/com/descope/internal/routes/EnchantedLink.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/EnchantedLink.kt
@@ -2,7 +2,6 @@ package com.descope.internal.routes
 
 import com.descope.internal.http.DescopeClient
 import com.descope.internal.http.EnchantedLinkServerResponse
-import com.descope.internal.others.with
 import com.descope.sdk.DescopeEnchantedLink
 import com.descope.sdk.DescopeLogger.Level.Error
 import com.descope.sdk.DescopeLogger.Level.Info
@@ -20,19 +19,19 @@ private const val DEFAULT_POLL_DURATION: Long = 2 /* mins */ * 60 /* secs */ * 1
 internal class EnchantedLink(override val client: DescopeClient) : Route, DescopeEnchantedLink {
 
     override suspend fun signUp(method: DeliveryMethod, loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkResponse =
-        client.enchantedLinkSignUp(method.asEnchantedLinkMethod(), loginId, details, uri).convert(method)
+        client.enchantedLinkSignUp(method, loginId, details, uri).convert()
 
     override suspend fun signIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkResponse =
-        client.enchantedLinkSignIn(method.asEnchantedLinkMethod(), loginId, uri, options).convert(method)
+        client.enchantedLinkSignIn(method, loginId, uri, options).convert()
 
     override suspend fun signUpOrIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkResponse =
-        client.enchantedLinkSignUpOrIn(method.asEnchantedLinkMethod(), loginId, uri, options).convert(method)
+        client.enchantedLinkSignUpOrIn(method, loginId, uri, options).convert()
 
     override suspend fun updateEmail(email: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkResponse =
-        client.enchantedLinkUpdateEmail(email, loginId, uri, refreshJwt, options).convert(DeliveryMethod.Email)
+        client.enchantedLinkUpdateEmail(email, loginId, uri, refreshJwt, options).convert()
 
     override suspend fun updatePhone(phone: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkResponse =
-        client.enchantedLinkUpdatePhone(phone, loginId, uri, refreshJwt, options).convert(DeliveryMethod.Sms)
+        client.enchantedLinkUpdatePhone(phone, loginId, uri, refreshJwt, options).convert()
 
     override suspend fun checkForSession(pendingRef: String): AuthenticationResponse =
         client.enchantedLinkCheckForSession(pendingRef).convert()
@@ -64,21 +63,9 @@ internal class EnchantedLink(override val client: DescopeClient) : Route, Descop
     }
 }
 
-private fun EnchantedLinkServerResponse.convert(method: DeliveryMethod) = when (method) {
-    DeliveryMethod.Email -> EnchantedLinkResponse(
-        linkId = linkId,
-        pendingRef = pendingRef,
-        maskedEmail = maskedEmail ?: throw DescopeException.decodeError.with(message = "masked email not received"),
-    )
-
-    else -> EnchantedLinkResponse(
-        linkId = linkId,
-        pendingRef = pendingRef,
-        maskedPhone = maskedPhone ?: throw DescopeException.decodeError.with(message = "masked phone not received"),
-    )
-}
-
-private fun DeliveryMethod.asEnchantedLinkMethod() = when (this) {
-    DeliveryMethod.Email, DeliveryMethod.Sms -> this
-    DeliveryMethod.Whatsapp -> throw DescopeException.invalidArguments.with(message = "Enchanted link is not delivered over WhatsApp")
-}
+private fun EnchantedLinkServerResponse.convert() = EnchantedLinkResponse(
+    linkId = linkId,
+    pendingRef = pendingRef,
+    maskedEmail = maskedEmail,
+    maskedPhone = maskedPhone,
+)

--- a/descopesdk/src/main/java/com/descope/internal/routes/EnchantedLink.kt
+++ b/descopesdk/src/main/java/com/descope/internal/routes/EnchantedLink.kt
@@ -9,7 +9,6 @@ import com.descope.sdk.DescopeLogger.Level.Info
 import com.descope.types.AuthenticationResponse
 import com.descope.types.DeliveryMethod
 import com.descope.types.DescopeException
-import com.descope.types.EnchantedLinkDeliveryResponse
 import com.descope.types.EnchantedLinkResponse
 import com.descope.types.SignInOptions
 import com.descope.types.SignUpDetails
@@ -20,28 +19,19 @@ private const val DEFAULT_POLL_DURATION: Long = 2 /* mins */ * 60 /* secs */ * 1
 
 internal class EnchantedLink(override val client: DescopeClient) : Route, DescopeEnchantedLink {
 
-    override suspend fun signUp(loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkResponse =
-        client.enchantedLinkSignUp(DeliveryMethod.Email, loginId, details, uri).convert()
-
-    override suspend fun signIn(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkResponse =
-        client.enchantedLinkSignIn(DeliveryMethod.Email, loginId, uri, options).convert()
-
-    override suspend fun signUpOrIn(loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkResponse =
-        client.enchantedLinkSignUpOrIn(DeliveryMethod.Email, loginId, uri, options).convert()
-
-    override suspend fun updateEmail(email: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkResponse =
-        client.enchantedLinkUpdateEmail(email, loginId, uri, refreshJwt, options).convert()
-
-    override suspend fun signUp(method: DeliveryMethod, loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkDeliveryResponse =
+    override suspend fun signUp(method: DeliveryMethod, loginId: String, details: SignUpDetails?, uri: String?): EnchantedLinkResponse =
         client.enchantedLinkSignUp(method.asEnchantedLinkMethod(), loginId, details, uri).convert(method)
 
-    override suspend fun signIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkDeliveryResponse =
+    override suspend fun signIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkResponse =
         client.enchantedLinkSignIn(method.asEnchantedLinkMethod(), loginId, uri, options).convert(method)
 
-    override suspend fun signUpOrIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkDeliveryResponse =
+    override suspend fun signUpOrIn(method: DeliveryMethod, loginId: String, uri: String?, options: List<SignInOptions>?): EnchantedLinkResponse =
         client.enchantedLinkSignUpOrIn(method.asEnchantedLinkMethod(), loginId, uri, options).convert(method)
 
-    override suspend fun updatePhone(phone: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkDeliveryResponse =
+    override suspend fun updateEmail(email: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkResponse =
+        client.enchantedLinkUpdateEmail(email, loginId, uri, refreshJwt, options).convert(DeliveryMethod.Email)
+
+    override suspend fun updatePhone(phone: String, loginId: String, uri: String?, refreshJwt: String, options: UpdateOptions?): EnchantedLinkResponse =
         client.enchantedLinkUpdatePhone(phone, loginId, uri, refreshJwt, options).convert(DeliveryMethod.Sms)
 
     override suspend fun checkForSession(pendingRef: String): AuthenticationResponse =
@@ -74,20 +64,14 @@ internal class EnchantedLink(override val client: DescopeClient) : Route, Descop
     }
 }
 
-private fun EnchantedLinkServerResponse.convert() = EnchantedLinkResponse(
-    linkId = linkId,
-    pendingRef = pendingRef,
-    maskedEmail = maskedEmail ?: throw DescopeException.decodeError.with(message = "masked email not received"),
-)
-
 private fun EnchantedLinkServerResponse.convert(method: DeliveryMethod) = when (method) {
-    DeliveryMethod.Email -> EnchantedLinkDeliveryResponse(
+    DeliveryMethod.Email -> EnchantedLinkResponse(
         linkId = linkId,
         pendingRef = pendingRef,
         maskedEmail = maskedEmail ?: throw DescopeException.decodeError.with(message = "masked email not received"),
     )
 
-    else -> EnchantedLinkDeliveryResponse(
+    else -> EnchantedLinkResponse(
         linkId = linkId,
         pendingRef = pendingRef,
         maskedPhone = maskedPhone ?: throw DescopeException.decodeError.with(message = "masked phone not received"),

--- a/descopesdk/src/main/java/com/descope/sdk/Routes.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Routes.kt
@@ -10,7 +10,6 @@ import com.descope.types.AuthenticationResponse
 import com.descope.types.DeliveryMethod
 import com.descope.types.DescopeTenant
 import com.descope.types.DescopeUser
-import com.descope.types.EnchantedLinkDeliveryResponse
 import com.descope.types.EnchantedLinkResponse
 import com.descope.types.RevokeType
 import com.descope.types.OAuthProvider
@@ -391,51 +390,68 @@ interface DescopeMagicLink {
  */
 interface DescopeEnchantedLink {
     /**
-     * Authenticates a new user using an enchanted link, sent via email.
+     * Authenticates a new user using an enchanted link, sent via a delivery [method] of choice.
      *
      * A new user identified by [loginId] and the optional [details] details will be added
-     * upon successful authentication.
+     * upon successful authentication. Enchanted links are delivered over
+     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
+     *
+     * - **Important:** Make sure the delivery information corresponding with
+     * the delivery [method] is given either in the optional [details] parameter or as
+     * the [loginId] itself, i.e., the email address or phone number.
      *
      * The caller should use the returned [EnchantedLinkResponse.linkId] to show the
-     * user which link they need to press in the enchanted link email, and then use
-     * the [EnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     * user which link they need to press, and then use the
+     * [EnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
      *
+     * @param method deliver the enchanted link using this method.
      * @param loginId the identifier of the user to authenticate.
-     * @param details optional user information. Should contain an email address if not provided in [loginId].
+     * @param details optional user information. Should contain the necessary delivery information if not provided in [loginId].
      * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
      * @return an [EnchantedLinkResponse] with the details necessary for polling and authenticating the user.
      */
-    suspend fun signUp(loginId: String, details: SignUpDetails? = null, uri: String? = null): EnchantedLinkResponse
+    suspend fun signUp(method: DeliveryMethod, loginId: String, details: SignUpDetails? = null, uri: String? = null): EnchantedLinkResponse
 
     /**
-     * Authenticates an existing user using an enchanted link, sent via email.
+     * Authenticates an existing user using an enchanted link, sent via a delivery [method] of choice.
      *
-     * An enchanted link will be sent to the user identified by [loginId].
+     * An enchanted link will be sent to the user identified by [loginId] over
+     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
+     *
+     * - **Important:** Make sure the delivery information corresponding with
+     * the delivery [method] already exists on the user trying to log in,
+     * i.e., the email address or phone number.
+     *
      * The caller should use the returned [EnchantedLinkResponse.linkId] to show the
-     * user which link they need to press in the enchanted link email, and then use
-     * the [EnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     * user which link they need to press, and then use the
+     * [EnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
      *
+     * @param method deliver the enchanted link using this method.
      * @param loginId the identifier of the user to authenticate.
      * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
      * @param options additional behaviors to perform during authentication.
      * @return an [EnchantedLinkResponse] with the details necessary for polling and authenticating the user.
      */
-    suspend fun signIn(loginId: String, uri: String? = null, options: List<SignInOptions>? = null): EnchantedLinkResponse
+    suspend fun signIn(method: DeliveryMethod, loginId: String, uri: String? = null, options: List<SignInOptions>? = null): EnchantedLinkResponse
 
     /**
      * Authenticates an existing user if one exists, or create a new user using an
-     * enchanted link, sent via email.
-     * 
+     * enchanted link, sent via a delivery [method] of choice.
+     *
+     * An enchanted link will be sent to the user identified by [loginId] over
+     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
+     *
      * The caller should use the returned [EnchantedLinkResponse.linkId] to show the
-     * user which link they need to press in the enchanted link email, and then use
-     * the [EnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
-     * 
+     * user which link they need to press, and then use the
+     * [EnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     *
+     * @param method deliver the enchanted link using this method.
      * @param loginId the identifier of the user to authenticate.
      * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
      * @param options additional behaviors to perform during authentication.
      * @return an [EnchantedLinkResponse] with the details necessary for polling and authenticating the user.
      */
-    suspend fun signUpOrIn(loginId: String, uri: String? = null, options: List<SignInOptions>? = null): EnchantedLinkResponse
+    suspend fun signUpOrIn(method: DeliveryMethod, loginId: String, uri: String? = null, options: List<SignInOptions>? = null): EnchantedLinkResponse
 
     /**
      * Updates an existing user by adding an [email] address.
@@ -460,79 +476,15 @@ interface DescopeEnchantedLink {
     suspend fun updateEmail(email: String, loginId: String, uri: String? = null, refreshJwt: String, options: UpdateOptions? = null): EnchantedLinkResponse
 
     /**
-     * Authenticates a new user using an enchanted link, sent via a delivery [method] of choice.
-     *
-     * A new user identified by [loginId] and the optional [details] details will be added
-     * upon successful authentication. Enchanted links are delivered over
-     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
-     *
-     * - **Important:** Make sure the delivery information corresponding with
-     * the delivery [method] is given either in the optional [details] parameter or as
-     * the [loginId] itself, i.e., the email address or phone number.
-     *
-     * The caller should use the returned [EnchantedLinkDeliveryResponse.linkId] to show the
-     * user which link they need to press, and then use the
-     * [EnchantedLinkDeliveryResponse.pendingRef] value to poll until the authentication is verified.
-     *
-     * @param method deliver the enchanted link using this method.
-     * @param loginId the identifier of the user to authenticate.
-     * @param details optional user information. Should contain the necessary delivery information if not provided in [loginId].
-     * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
-     * @return an [EnchantedLinkDeliveryResponse] with the details necessary for polling and authenticating the user.
-     */
-    suspend fun signUp(method: DeliveryMethod, loginId: String, details: SignUpDetails? = null, uri: String? = null): EnchantedLinkDeliveryResponse
-
-    /**
-     * Authenticates an existing user using an enchanted link, sent via a delivery [method] of choice.
-     *
-     * An enchanted link will be sent to the user identified by [loginId] over
-     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
-     *
-     * - **Important:** Make sure the delivery information corresponding with
-     * the delivery [method] already exists on the user trying to log in,
-     * i.e., the email address or phone number.
-     *
-     * The caller should use the returned [EnchantedLinkDeliveryResponse.linkId] to show the
-     * user which link they need to press, and then use the
-     * [EnchantedLinkDeliveryResponse.pendingRef] value to poll until the authentication is verified.
-     *
-     * @param method deliver the enchanted link using this method.
-     * @param loginId the identifier of the user to authenticate.
-     * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
-     * @param options additional behaviors to perform during authentication.
-     * @return an [EnchantedLinkDeliveryResponse] with the details necessary for polling and authenticating the user.
-     */
-    suspend fun signIn(method: DeliveryMethod, loginId: String, uri: String? = null, options: List<SignInOptions>? = null): EnchantedLinkDeliveryResponse
-
-    /**
-     * Authenticates an existing user if one exists, or create a new user using an
-     * enchanted link, sent via a delivery [method] of choice.
-     *
-     * An enchanted link will be sent to the user identified by [loginId] over
-     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
-     *
-     * The caller should use the returned [EnchantedLinkDeliveryResponse.linkId] to show the
-     * user which link they need to press, and then use the
-     * [EnchantedLinkDeliveryResponse.pendingRef] value to poll until the authentication is verified.
-     *
-     * @param method deliver the enchanted link using this method.
-     * @param loginId the identifier of the user to authenticate.
-     * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
-     * @param options additional behaviors to perform during authentication.
-     * @return an [EnchantedLinkDeliveryResponse] with the details necessary for polling and authenticating the user.
-     */
-    suspend fun signUpOrIn(method: DeliveryMethod, loginId: String, uri: String? = null, options: List<SignInOptions>? = null): EnchantedLinkDeliveryResponse
-
-    /**
      * Updates an existing user by adding a [phone] number.
      *
      * The [phone] number will be updated after it is verified via an enchanted link sent
      * over SMS. In order to do this, the user must have an active [DescopeSession] whose
      * [refreshJwt] should be passed as a parameter to this function.
      *
-     * The caller should use the returned [EnchantedLinkDeliveryResponse.linkId] to show the
+     * The caller should use the returned [EnchantedLinkResponse.linkId] to show the
      * user which link they need to press in the enchanted link text message, and then use
-     * the [EnchantedLinkDeliveryResponse.pendingRef] value to poll until the authentication is verified.
+     * the [EnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
      *
      * @param phone the phone number to add to the user profile.
      * @param loginId the identifier of the user to update.
@@ -541,9 +493,9 @@ interface DescopeEnchantedLink {
      * @param options Whether to add the new phone number as a loginId for the updated user, and
      * in that case, if another user already has the same phone number as a loginId how to
      * merge the two users. See the documentation for [UpdateOptions] for more details.
-     * @return an [EnchantedLinkDeliveryResponse] with the details necessary for polling and authenticating the user.
+     * @return an [EnchantedLinkResponse] with the details necessary for polling and authenticating the user.
      */
-    suspend fun updatePhone(phone: String, loginId: String, uri: String? = null, refreshJwt: String, options: UpdateOptions? = null): EnchantedLinkDeliveryResponse
+    suspend fun updatePhone(phone: String, loginId: String, uri: String? = null, refreshJwt: String, options: UpdateOptions? = null): EnchantedLinkResponse
 
     /**
      * Checks if an enchanted link authentication has been verified by the user.

--- a/descopesdk/src/main/java/com/descope/sdk/Routes.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Routes.kt
@@ -14,6 +14,7 @@ import com.descope.types.EnchantedLinkResponse
 import com.descope.types.RevokeType
 import com.descope.types.OAuthProvider
 import com.descope.types.PasswordPolicy
+import com.descope.types.PhoneEnchantedLinkResponse
 import com.descope.types.RefreshResponse
 import com.descope.types.SignInOptions
 import com.descope.types.SignUpDetails
@@ -457,6 +458,75 @@ interface DescopeEnchantedLink {
      * @return masked email address the magic link was sent to.
      */
     suspend fun updateEmail(email: String, loginId: String, uri: String? = null, refreshJwt: String, options: UpdateOptions? = null): EnchantedLinkResponse
+
+    /**
+     * Authenticates a new user using an enchanted link, sent via text message.
+     *
+     * A new user identified by [loginId] and the optional [details] details will be added
+     * upon successful authentication.
+     *
+     * The caller should use the returned [PhoneEnchantedLinkResponse.linkId] to show the
+     * user which link they need to press in the enchanted link text message, and then use
+     * the [PhoneEnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     *
+     * @param loginId the identifier of the user to authenticate.
+     * @param details optional user information. Should contain a phone number if not provided in [loginId].
+     * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
+     * @return a [PhoneEnchantedLinkResponse] with the details necessary for polling and authenticating the user.
+     */
+    suspend fun signUpWithPhone(loginId: String, details: SignUpDetails? = null, uri: String? = null): PhoneEnchantedLinkResponse
+
+    /**
+     * Authenticates an existing user using an enchanted link, sent via text message.
+     *
+     * An enchanted link will be sent to the user identified by [loginId].
+     * The caller should use the returned [PhoneEnchantedLinkResponse.linkId] to show the
+     * user which link they need to press in the enchanted link text message, and then use
+     * the [PhoneEnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     *
+     * @param loginId the identifier of the user to authenticate.
+     * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
+     * @param options additional behaviors to perform during authentication.
+     * @return a [PhoneEnchantedLinkResponse] with the details necessary for polling and authenticating the user.
+     */
+    suspend fun signInWithPhone(loginId: String, uri: String? = null, options: List<SignInOptions>? = null): PhoneEnchantedLinkResponse
+
+    /**
+     * Authenticates an existing user if one exists, or create a new user using an
+     * enchanted link, sent via text message.
+     *
+     * The caller should use the returned [PhoneEnchantedLinkResponse.linkId] to show the
+     * user which link they need to press in the enchanted link text message, and then use
+     * the [PhoneEnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     *
+     * @param loginId the identifier of the user to authenticate.
+     * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
+     * @param options additional behaviors to perform during authentication.
+     * @return a [PhoneEnchantedLinkResponse] with the details necessary for polling and authenticating the user.
+     */
+    suspend fun signUpOrInWithPhone(loginId: String, uri: String? = null, options: List<SignInOptions>? = null): PhoneEnchantedLinkResponse
+
+    /**
+     * Updates an existing user by adding a [phone] number.
+     *
+     * The [phone] number will be updated after it is verified via enchanted link. In order to
+     * do this, the user must have an active [DescopeSession] whose [refreshJwt] should
+     * be passed as a parameter to this function.
+     *
+     * The caller should use the returned [PhoneEnchantedLinkResponse.linkId] to show the
+     * user which link they need to press in the enchanted link text message, and then use
+     * the [PhoneEnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     *
+     * @param phone the phone number to add to the user profile.
+     * @param loginId the identifier of the user to update.
+     * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
+     * @param refreshJwt the refreshJwt from an active [DescopeSession].
+     * @param options Whether to add the new phone number as a loginId for the updated user, and
+     * in that case, if another user already has the same phone number as a loginId how to
+     * merge the two users. See the documentation for [UpdateOptions] for more details.
+     * @return a [PhoneEnchantedLinkResponse] with the details necessary for polling and authenticating the user.
+     */
+    suspend fun updatePhone(phone: String, loginId: String, uri: String? = null, refreshJwt: String, options: UpdateOptions? = null): PhoneEnchantedLinkResponse
 
     /**
      * Checks if an enchanted link authentication has been verified by the user.

--- a/descopesdk/src/main/java/com/descope/sdk/Routes.kt
+++ b/descopesdk/src/main/java/com/descope/sdk/Routes.kt
@@ -10,11 +10,11 @@ import com.descope.types.AuthenticationResponse
 import com.descope.types.DeliveryMethod
 import com.descope.types.DescopeTenant
 import com.descope.types.DescopeUser
+import com.descope.types.EnchantedLinkDeliveryResponse
 import com.descope.types.EnchantedLinkResponse
 import com.descope.types.RevokeType
 import com.descope.types.OAuthProvider
 import com.descope.types.PasswordPolicy
-import com.descope.types.PhoneEnchantedLinkResponse
 import com.descope.types.RefreshResponse
 import com.descope.types.SignInOptions
 import com.descope.types.SignUpDetails
@@ -460,62 +460,79 @@ interface DescopeEnchantedLink {
     suspend fun updateEmail(email: String, loginId: String, uri: String? = null, refreshJwt: String, options: UpdateOptions? = null): EnchantedLinkResponse
 
     /**
-     * Authenticates a new user using an enchanted link, sent via text message.
+     * Authenticates a new user using an enchanted link, sent via a delivery [method] of choice.
      *
      * A new user identified by [loginId] and the optional [details] details will be added
-     * upon successful authentication.
+     * upon successful authentication. Enchanted links are delivered over
+     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
      *
-     * The caller should use the returned [PhoneEnchantedLinkResponse.linkId] to show the
-     * user which link they need to press in the enchanted link text message, and then use
-     * the [PhoneEnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     * - **Important:** Make sure the delivery information corresponding with
+     * the delivery [method] is given either in the optional [details] parameter or as
+     * the [loginId] itself, i.e., the email address or phone number.
      *
+     * The caller should use the returned [EnchantedLinkDeliveryResponse.linkId] to show the
+     * user which link they need to press, and then use the
+     * [EnchantedLinkDeliveryResponse.pendingRef] value to poll until the authentication is verified.
+     *
+     * @param method deliver the enchanted link using this method.
      * @param loginId the identifier of the user to authenticate.
-     * @param details optional user information. Should contain a phone number if not provided in [loginId].
+     * @param details optional user information. Should contain the necessary delivery information if not provided in [loginId].
      * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
-     * @return a [PhoneEnchantedLinkResponse] with the details necessary for polling and authenticating the user.
+     * @return an [EnchantedLinkDeliveryResponse] with the details necessary for polling and authenticating the user.
      */
-    suspend fun signUpWithPhone(loginId: String, details: SignUpDetails? = null, uri: String? = null): PhoneEnchantedLinkResponse
+    suspend fun signUp(method: DeliveryMethod, loginId: String, details: SignUpDetails? = null, uri: String? = null): EnchantedLinkDeliveryResponse
 
     /**
-     * Authenticates an existing user using an enchanted link, sent via text message.
+     * Authenticates an existing user using an enchanted link, sent via a delivery [method] of choice.
      *
-     * An enchanted link will be sent to the user identified by [loginId].
-     * The caller should use the returned [PhoneEnchantedLinkResponse.linkId] to show the
-     * user which link they need to press in the enchanted link text message, and then use
-     * the [PhoneEnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     * An enchanted link will be sent to the user identified by [loginId] over
+     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
      *
+     * - **Important:** Make sure the delivery information corresponding with
+     * the delivery [method] already exists on the user trying to log in,
+     * i.e., the email address or phone number.
+     *
+     * The caller should use the returned [EnchantedLinkDeliveryResponse.linkId] to show the
+     * user which link they need to press, and then use the
+     * [EnchantedLinkDeliveryResponse.pendingRef] value to poll until the authentication is verified.
+     *
+     * @param method deliver the enchanted link using this method.
      * @param loginId the identifier of the user to authenticate.
      * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
      * @param options additional behaviors to perform during authentication.
-     * @return a [PhoneEnchantedLinkResponse] with the details necessary for polling and authenticating the user.
+     * @return an [EnchantedLinkDeliveryResponse] with the details necessary for polling and authenticating the user.
      */
-    suspend fun signInWithPhone(loginId: String, uri: String? = null, options: List<SignInOptions>? = null): PhoneEnchantedLinkResponse
+    suspend fun signIn(method: DeliveryMethod, loginId: String, uri: String? = null, options: List<SignInOptions>? = null): EnchantedLinkDeliveryResponse
 
     /**
      * Authenticates an existing user if one exists, or create a new user using an
-     * enchanted link, sent via text message.
+     * enchanted link, sent via a delivery [method] of choice.
      *
-     * The caller should use the returned [PhoneEnchantedLinkResponse.linkId] to show the
-     * user which link they need to press in the enchanted link text message, and then use
-     * the [PhoneEnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     * An enchanted link will be sent to the user identified by [loginId] over
+     * [DeliveryMethod.Email] or [DeliveryMethod.Sms].
      *
+     * The caller should use the returned [EnchantedLinkDeliveryResponse.linkId] to show the
+     * user which link they need to press, and then use the
+     * [EnchantedLinkDeliveryResponse.pendingRef] value to poll until the authentication is verified.
+     *
+     * @param method deliver the enchanted link using this method.
      * @param loginId the identifier of the user to authenticate.
      * @param uri optional enchanted link URI. If not given, the default URI from the Descope console will be used.
      * @param options additional behaviors to perform during authentication.
-     * @return a [PhoneEnchantedLinkResponse] with the details necessary for polling and authenticating the user.
+     * @return an [EnchantedLinkDeliveryResponse] with the details necessary for polling and authenticating the user.
      */
-    suspend fun signUpOrInWithPhone(loginId: String, uri: String? = null, options: List<SignInOptions>? = null): PhoneEnchantedLinkResponse
+    suspend fun signUpOrIn(method: DeliveryMethod, loginId: String, uri: String? = null, options: List<SignInOptions>? = null): EnchantedLinkDeliveryResponse
 
     /**
      * Updates an existing user by adding a [phone] number.
      *
-     * The [phone] number will be updated after it is verified via enchanted link. In order to
-     * do this, the user must have an active [DescopeSession] whose [refreshJwt] should
-     * be passed as a parameter to this function.
+     * The [phone] number will be updated after it is verified via an enchanted link sent
+     * over SMS. In order to do this, the user must have an active [DescopeSession] whose
+     * [refreshJwt] should be passed as a parameter to this function.
      *
-     * The caller should use the returned [PhoneEnchantedLinkResponse.linkId] to show the
+     * The caller should use the returned [EnchantedLinkDeliveryResponse.linkId] to show the
      * user which link they need to press in the enchanted link text message, and then use
-     * the [PhoneEnchantedLinkResponse.pendingRef] value to poll until the authentication is verified.
+     * the [EnchantedLinkDeliveryResponse.pendingRef] value to poll until the authentication is verified.
      *
      * @param phone the phone number to add to the user profile.
      * @param loginId the identifier of the user to update.
@@ -524,9 +541,9 @@ interface DescopeEnchantedLink {
      * @param options Whether to add the new phone number as a loginId for the updated user, and
      * in that case, if another user already has the same phone number as a loginId how to
      * merge the two users. See the documentation for [UpdateOptions] for more details.
-     * @return a [PhoneEnchantedLinkResponse] with the details necessary for polling and authenticating the user.
+     * @return an [EnchantedLinkDeliveryResponse] with the details necessary for polling and authenticating the user.
      */
-    suspend fun updatePhone(phone: String, loginId: String, uri: String? = null, refreshJwt: String, options: UpdateOptions? = null): PhoneEnchantedLinkResponse
+    suspend fun updatePhone(phone: String, loginId: String, uri: String? = null, refreshJwt: String, options: UpdateOptions? = null): EnchantedLinkDeliveryResponse
 
     /**
      * Checks if an enchanted link authentication has been verified by the user.

--- a/descopesdk/src/main/java/com/descope/types/Responses.kt
+++ b/descopesdk/src/main/java/com/descope/types/Responses.kt
@@ -54,22 +54,24 @@ data class EnchantedLinkResponse(
 )
 
 /**
- * Returned from calls that start an enchanted link flow over SMS.
+ * Returned from enchanted link calls that take an explicit [DeliveryMethod].
  *
  * The [linkId] value needs to be displayed to the user so they know which
- * link should be clicked on in the enchanted link text message. The [maskedPhone]
- * field can also be shown to inform the user to which phone number the text
- * message was sent. The [pendingRef] field is used to poll the server for the
- * enchanted link flow result.
+ * link should be clicked on in the enchanted link email or text message. The
+ * [maskedEmail] or [maskedPhone] field matching the delivery method used can
+ * also be shown to inform the user where the link was sent. The [pendingRef]
+ * field is used to poll the server for the enchanted link flow result.
  *
  * @property linkId which link the user should click on
  * @property pendingRef poll for session using this reference
- * @property maskedPhone a masked version of the phone number the link was sent to
+ * @property maskedEmail a masked version of the email address the link was sent to, when delivered by email
+ * @property maskedPhone a masked version of the phone number the link was sent to, when delivered by SMS
  */
-data class PhoneEnchantedLinkResponse(
+data class EnchantedLinkDeliveryResponse(
     val linkId: String,
     val pendingRef: String,
-    val maskedPhone: String,
+    val maskedEmail: String? = null,
+    val maskedPhone: String? = null,
 )
 
 /**

--- a/descopesdk/src/main/java/com/descope/types/Responses.kt
+++ b/descopesdk/src/main/java/com/descope/types/Responses.kt
@@ -38,25 +38,6 @@ data class RefreshResponse(
  * Returned from calls that start an enchanted link flow.
  *
  * The [linkId] value needs to be displayed to the user so they know which
- * link should be clicked on in the enchanted link email. The [maskedEmail]
- * field can also be shown to inform the user to which address the email
- * was sent. The [pendingRef] field is used to poll the server for the
- * enchanted link flow result.
- *
- * @property linkId which link the user should click on
- * @property pendingRef poll for session using this reference
- * @property maskedEmail a masked version of the email address the link was sent to
- */
-data class EnchantedLinkResponse(
-    val linkId: String,
-    val pendingRef: String,
-    val maskedEmail: String,
-)
-
-/**
- * Returned from enchanted link calls that take an explicit [DeliveryMethod].
- *
- * The [linkId] value needs to be displayed to the user so they know which
  * link should be clicked on in the enchanted link email or text message. The
  * [maskedEmail] or [maskedPhone] field matching the delivery method used can
  * also be shown to inform the user where the link was sent. The [pendingRef]
@@ -67,7 +48,7 @@ data class EnchantedLinkResponse(
  * @property maskedEmail a masked version of the email address the link was sent to, when delivered by email
  * @property maskedPhone a masked version of the phone number the link was sent to, when delivered by SMS
  */
-data class EnchantedLinkDeliveryResponse(
+data class EnchantedLinkResponse(
     val linkId: String,
     val pendingRef: String,
     val maskedEmail: String? = null,

--- a/descopesdk/src/main/java/com/descope/types/Responses.kt
+++ b/descopesdk/src/main/java/com/descope/types/Responses.kt
@@ -54,6 +54,25 @@ data class EnchantedLinkResponse(
 )
 
 /**
+ * Returned from calls that start an enchanted link flow over SMS.
+ *
+ * The [linkId] value needs to be displayed to the user so they know which
+ * link should be clicked on in the enchanted link text message. The [maskedPhone]
+ * field can also be shown to inform the user to which phone number the text
+ * message was sent. The [pendingRef] field is used to poll the server for the
+ * enchanted link flow result.
+ *
+ * @property linkId which link the user should click on
+ * @property pendingRef poll for session using this reference
+ * @property maskedPhone a masked version of the phone number the link was sent to
+ */
+data class PhoneEnchantedLinkResponse(
+    val linkId: String,
+    val pendingRef: String,
+    val maskedPhone: String,
+)
+
+/**
  * Returned from TOTP calls that create a new seed.
  *
  * The [provisioningUrl] field wraps the key (seed) in a URL that can be

--- a/descopesdk/src/test/java/com/descope/internal/routes/EnchantedLinkTest.kt
+++ b/descopesdk/src/test/java/com/descope/internal/routes/EnchantedLinkTest.kt
@@ -6,6 +6,7 @@ import com.descope.types.SignUpDetails
 import com.descope.types.UpdateOptions
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class EnchantedLinkTest {
@@ -74,6 +75,81 @@ class EnchantedLinkTest {
         }
         client.response = EnchantedLinkServerResponse("linkId", "pendingRef", "maskedEmail")
         enchantedLink.updateEmail("test2@test.com", loginId, refreshJwt = "refreshJwt", options = options)
+        assertEquals(1, client.calls)
+    }
+
+    @Test
+    fun signUpWithPhone() = runTest {
+        val loginId = "+972123456789"
+        val details = SignUpDetails(name = "a", phone = loginId, givenName = "b", middleName = "c", familyName = "d")
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
+            assertEquals("auth/enchantedlink/signup/sms", route)
+            assertEquals(loginId, body["loginId"])
+            details.validate(body)
+        }
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedPhone = "maskedPhone")
+        val response = enchantedLink.signUpWithPhone(loginId, details)
+        assertEquals("maskedPhone", response.maskedPhone)
+        assertEquals("linkId", response.linkId)
+        assertEquals("pendingRef", response.pendingRef)
+        assertEquals(1, client.calls)
+    }
+
+    @Test
+    fun signInWithPhone() = runTest {
+        val loginId = "+972123456789"
+        val uri = "https://mysite.com"
+        val options = listOf(SignInOptions.CustomClaims(mapOf("a" to "b")), SignInOptions.Mfa("refreshJwt"))
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
+            assertEquals("auth/enchantedlink/signin/sms", route)
+            assertEquals(loginId, body["loginId"])
+            assertEquals(uri, body["redirectUrl"])
+            options.validate(body)
+        }
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedPhone = "maskedPhone")
+        val response = enchantedLink.signInWithPhone(loginId, uri, options)
+        assertEquals("maskedPhone", response.maskedPhone)
+        assertEquals(1, client.calls)
+    }
+
+    @Test
+    fun signUpOrInWithPhone() = runTest {
+        val loginId = "+972123456789"
+        val options = listOf(SignInOptions.StepUp("refreshJwt"))
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
+            assertEquals("auth/enchantedlink/signup-in/sms", route)
+            assertEquals(loginId, body["loginId"])
+            options.validate(body)
+        }
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedPhone = "maskedPhone")
+        val response = enchantedLink.signUpOrInWithPhone(loginId, options = options)
+        assertEquals("maskedPhone", response.maskedPhone)
+        assertEquals(1, client.calls)
+    }
+
+    @Test
+    fun updatePhone() = runTest {
+        val loginId = "test@test.com"
+        val phone = "+972123456789"
+        val options = UpdateOptions(addToLoginIds = true, onMergeUseExisting = false)
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.assert = { route: String, body: Map<String, Any?>, headers: Map<String, String>, _: Map<String, String?> ->
+            assertEquals("auth/enchantedlink/update/phone/sms", route)
+            assertEquals(loginId, body["loginId"])
+            assertEquals(phone, body["phone"])
+            assertTrue(headers["Authorization"]!!.contains("refreshJwt"))
+            options.validate(body)
+        }
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedPhone = "maskedPhone")
+        val response = enchantedLink.updatePhone(phone, loginId, refreshJwt = "refreshJwt", options = options)
+        assertEquals("maskedPhone", response.maskedPhone)
         assertEquals(1, client.calls)
     }
 

--- a/descopesdk/src/test/java/com/descope/internal/routes/EnchantedLinkTest.kt
+++ b/descopesdk/src/test/java/com/descope/internal/routes/EnchantedLinkTest.kt
@@ -2,7 +2,6 @@ package com.descope.internal.routes
 
 import com.descope.internal.http.EnchantedLinkServerResponse
 import com.descope.types.DeliveryMethod
-import com.descope.types.DescopeException
 import com.descope.types.SignInOptions
 import com.descope.types.SignUpDetails
 import com.descope.types.UpdateOptions
@@ -10,7 +9,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Test
 
 class EnchantedLinkTest {
@@ -141,47 +139,6 @@ class EnchantedLinkTest {
         client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedPhone = "maskedPhone")
         val response = enchantedLink.signUpOrIn(DeliveryMethod.Sms, loginId, options = options)
         assertEquals("maskedPhone", response.maskedPhone)
-        assertEquals(1, client.calls)
-    }
-
-    @Test
-    fun whatsappIsRejectedWithoutCallingTheServer() = runTest {
-        val client = MockClient()
-        val enchantedLink = EnchantedLink(client)
-        try {
-            enchantedLink.signUpOrIn(DeliveryMethod.Whatsapp, "+972123456789")
-            fail("Expected a DescopeException to be thrown")
-        } catch (e: DescopeException) {
-            assertEquals(DescopeException.invalidArguments.code, e.code)
-        }
-        assertEquals(0, client.calls)
-    }
-
-    @Test
-    fun missingMaskedEmailFailsToDecode() = runTest {
-        val client = MockClient()
-        val enchantedLink = EnchantedLink(client)
-        client.response = EnchantedLinkServerResponse("linkId", "pendingRef")
-        try {
-            enchantedLink.signUpOrIn(DeliveryMethod.Email, "test@test.com")
-            fail("Expected a DescopeException to be thrown")
-        } catch (e: DescopeException) {
-            assertEquals("masked email not received", e.message)
-        }
-        assertEquals(1, client.calls)
-    }
-
-    @Test
-    fun missingMaskedPhoneFailsToDecode() = runTest {
-        val client = MockClient()
-        val enchantedLink = EnchantedLink(client)
-        client.response = EnchantedLinkServerResponse("linkId", "pendingRef")
-        try {
-            enchantedLink.signUpOrIn(DeliveryMethod.Sms, "+972123456789")
-            fail("Expected a DescopeException to be thrown")
-        } catch (e: DescopeException) {
-            assertEquals("masked phone not received", e.message)
-        }
         assertEquals(1, client.calls)
     }
 

--- a/descopesdk/src/test/java/com/descope/internal/routes/EnchantedLinkTest.kt
+++ b/descopesdk/src/test/java/com/descope/internal/routes/EnchantedLinkTest.kt
@@ -15,57 +15,6 @@ import org.junit.Test
 
 class EnchantedLinkTest {
     @Test
-    fun signUp() = runTest {
-        val loginId = "test@test.com"
-        val details = SignUpDetails(name = "a", email = loginId, givenName = "b", middleName = "c", familyName = "d")
-        val client = MockClient()
-        val enchantedLink = EnchantedLink(client)
-        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
-            assertEquals("auth/enchantedlink/signup/email", route)
-            assertEquals(loginId, body["loginId"])
-            details.validate(body)
-        }
-        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", "maskedEmail")
-        val response = enchantedLink.signUp(loginId, details)
-        assertEquals("maskedEmail", response.maskedEmail)
-        assertEquals(1, client.calls)
-    }
-
-    @Test
-    fun signIn() = runTest {
-        val loginId = "test@test.com"
-        val uri = "https://mysite.com"
-        val options = listOf(SignInOptions.CustomClaims(mapOf("a" to "b")), SignInOptions.Mfa("refreshJwt"))
-        val client = MockClient()
-        val enchantedLink = EnchantedLink(client)
-        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
-            assertEquals("auth/enchantedlink/signin/email", route)
-            assertEquals(loginId, body["loginId"])
-            assertEquals(uri, body["redirectUrl"])
-            options.validate(body)
-        }
-        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", "maskedEmail")
-        enchantedLink.signIn(loginId, uri, options)
-        assertEquals(1, client.calls)
-    }
-
-    @Test
-    fun signUpOrIn() = runTest {
-        val loginId = "test@test.com"
-        val options = listOf(SignInOptions.StepUp("refreshJwt"))
-        val client = MockClient()
-        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
-            assertEquals("auth/enchantedlink/signup-in/email", route)
-            assertEquals(loginId, body["loginId"])
-            options.validate(body)
-        }
-        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", "maskedEmail")
-        val enchantedLink = EnchantedLink(client)
-        enchantedLink.signUpOrIn(loginId, options = options)
-        assertEquals(1, client.calls)
-    }
-
-    @Test
     fun updateEmail() = runTest {
         val loginId = "test@test.com"
         val options = UpdateOptions(addToLoginIds = true, onMergeUseExisting = false)
@@ -77,8 +26,10 @@ class EnchantedLinkTest {
             assertEquals("test2@test.com", body["email"])
             options.validate(body)
         }
-        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", "maskedEmail")
-        enchantedLink.updateEmail("test2@test.com", loginId, refreshJwt = "refreshJwt", options = options)
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedEmail = "maskedEmail")
+        val response = enchantedLink.updateEmail("test2@test.com", loginId, refreshJwt = "refreshJwt", options = options)
+        assertEquals("maskedEmail", response.maskedEmail)
+        assertNull(response.maskedPhone)
         assertEquals(1, client.calls)
     }
 
@@ -97,6 +48,43 @@ class EnchantedLinkTest {
         val response = enchantedLink.signUp(DeliveryMethod.Email, loginId, details)
         assertEquals("maskedEmail", response.maskedEmail)
         assertNull(response.maskedPhone)
+        assertEquals(1, client.calls)
+    }
+
+    @Test
+    fun signInOverEmail() = runTest {
+        val loginId = "test@test.com"
+        val uri = "https://mysite.com"
+        val options = listOf(SignInOptions.CustomClaims(mapOf("a" to "b")), SignInOptions.Mfa("refreshJwt"))
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
+            assertEquals("auth/enchantedlink/signin/email", route)
+            assertEquals(loginId, body["loginId"])
+            assertEquals(uri, body["redirectUrl"])
+            options.validate(body)
+        }
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedEmail = "maskedEmail")
+        val response = enchantedLink.signIn(DeliveryMethod.Email, loginId, uri, options)
+        assertEquals("maskedEmail", response.maskedEmail)
+        assertNull(response.maskedPhone)
+        assertEquals(1, client.calls)
+    }
+
+    @Test
+    fun signUpOrInOverEmail() = runTest {
+        val loginId = "test@test.com"
+        val options = listOf(SignInOptions.StepUp("refreshJwt"))
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
+            assertEquals("auth/enchantedlink/signup-in/email", route)
+            assertEquals(loginId, body["loginId"])
+            options.validate(body)
+        }
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedEmail = "maskedEmail")
+        val response = enchantedLink.signUpOrIn(DeliveryMethod.Email, loginId, options = options)
+        assertEquals("maskedEmail", response.maskedEmail)
         assertEquals(1, client.calls)
     }
 
@@ -167,6 +155,20 @@ class EnchantedLinkTest {
             assertEquals(DescopeException.invalidArguments.code, e.code)
         }
         assertEquals(0, client.calls)
+    }
+
+    @Test
+    fun missingMaskedEmailFailsToDecode() = runTest {
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef")
+        try {
+            enchantedLink.signUpOrIn(DeliveryMethod.Email, "test@test.com")
+            fail("Expected a DescopeException to be thrown")
+        } catch (e: DescopeException) {
+            assertEquals("masked email not received", e.message)
+        }
+        assertEquals(1, client.calls)
     }
 
     @Test

--- a/descopesdk/src/test/java/com/descope/internal/routes/EnchantedLinkTest.kt
+++ b/descopesdk/src/test/java/com/descope/internal/routes/EnchantedLinkTest.kt
@@ -1,12 +1,16 @@
 package com.descope.internal.routes
 
 import com.descope.internal.http.EnchantedLinkServerResponse
+import com.descope.types.DeliveryMethod
+import com.descope.types.DescopeException
 import com.descope.types.SignInOptions
 import com.descope.types.SignUpDetails
 import com.descope.types.UpdateOptions
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class EnchantedLinkTest {
@@ -79,7 +83,25 @@ class EnchantedLinkTest {
     }
 
     @Test
-    fun signUpWithPhone() = runTest {
+    fun signUpOverEmail() = runTest {
+        val loginId = "test@test.com"
+        val details = SignUpDetails(name = "a", email = loginId, givenName = "b", middleName = "c", familyName = "d")
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.assert = { route: String, body: Map<String, Any?>, _: Map<String, String>, _: Map<String, String?> ->
+            assertEquals("auth/enchantedlink/signup/email", route)
+            assertEquals(loginId, body["loginId"])
+            details.validate(body)
+        }
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedEmail = "maskedEmail")
+        val response = enchantedLink.signUp(DeliveryMethod.Email, loginId, details)
+        assertEquals("maskedEmail", response.maskedEmail)
+        assertNull(response.maskedPhone)
+        assertEquals(1, client.calls)
+    }
+
+    @Test
+    fun signUpOverSms() = runTest {
         val loginId = "+972123456789"
         val details = SignUpDetails(name = "a", phone = loginId, givenName = "b", middleName = "c", familyName = "d")
         val client = MockClient()
@@ -90,15 +112,16 @@ class EnchantedLinkTest {
             details.validate(body)
         }
         client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedPhone = "maskedPhone")
-        val response = enchantedLink.signUpWithPhone(loginId, details)
+        val response = enchantedLink.signUp(DeliveryMethod.Sms, loginId, details)
         assertEquals("maskedPhone", response.maskedPhone)
+        assertNull(response.maskedEmail)
         assertEquals("linkId", response.linkId)
         assertEquals("pendingRef", response.pendingRef)
         assertEquals(1, client.calls)
     }
 
     @Test
-    fun signInWithPhone() = runTest {
+    fun signInOverSms() = runTest {
         val loginId = "+972123456789"
         val uri = "https://mysite.com"
         val options = listOf(SignInOptions.CustomClaims(mapOf("a" to "b")), SignInOptions.Mfa("refreshJwt"))
@@ -111,13 +134,13 @@ class EnchantedLinkTest {
             options.validate(body)
         }
         client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedPhone = "maskedPhone")
-        val response = enchantedLink.signInWithPhone(loginId, uri, options)
+        val response = enchantedLink.signIn(DeliveryMethod.Sms, loginId, uri, options)
         assertEquals("maskedPhone", response.maskedPhone)
         assertEquals(1, client.calls)
     }
 
     @Test
-    fun signUpOrInWithPhone() = runTest {
+    fun signUpOrInOverSms() = runTest {
         val loginId = "+972123456789"
         val options = listOf(SignInOptions.StepUp("refreshJwt"))
         val client = MockClient()
@@ -128,8 +151,35 @@ class EnchantedLinkTest {
             options.validate(body)
         }
         client.response = EnchantedLinkServerResponse("linkId", "pendingRef", maskedPhone = "maskedPhone")
-        val response = enchantedLink.signUpOrInWithPhone(loginId, options = options)
+        val response = enchantedLink.signUpOrIn(DeliveryMethod.Sms, loginId, options = options)
         assertEquals("maskedPhone", response.maskedPhone)
+        assertEquals(1, client.calls)
+    }
+
+    @Test
+    fun whatsappIsRejectedWithoutCallingTheServer() = runTest {
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        try {
+            enchantedLink.signUpOrIn(DeliveryMethod.Whatsapp, "+972123456789")
+            fail("Expected a DescopeException to be thrown")
+        } catch (e: DescopeException) {
+            assertEquals(DescopeException.invalidArguments.code, e.code)
+        }
+        assertEquals(0, client.calls)
+    }
+
+    @Test
+    fun missingMaskedPhoneFailsToDecode() = runTest {
+        val client = MockClient()
+        val enchantedLink = EnchantedLink(client)
+        client.response = EnchantedLinkServerResponse("linkId", "pendingRef")
+        try {
+            enchantedLink.signUpOrIn(DeliveryMethod.Sms, "+972123456789")
+            fail("Expected a DescopeException to be thrown")
+        } catch (e: DescopeException) {
+            assertEquals("masked phone not received", e.message)
+        }
         assertEquals(1, client.calls)
     }
 


### PR DESCRIPTION
Adds Enchanted Link over SMS to descope-kotlin.

- Every verb now takes a `DeliveryMethod` first, matching the magic link route.
- One response type: `EnchantedLinkResponse` carries nullable `maskedEmail` and `maskedPhone`.
- Removes the email-only `signUp`/`signIn`/`signUpOrIn` overloads and `EnchantedLinkDeliveryResponse` — pass `DeliveryMethod.Email` instead.
- `maskedEmail` is now nullable, so callers reading it as non-null need updating.

Part of descope/etc#18315
